### PR TITLE
IPTCParser now takes the raw bytes of an IPTCRecord element into account

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -438,10 +438,20 @@ public class IptcParser extends BinaryFileParser {
                 }
                 bos.write(element.iptcType.getType());
 
-                final byte[] recordData = element.value.getBytes("ISO-8859-1");
-                if (!new String(recordData, "ISO-8859-1").equals(element.value)) {
-                    throw new ImageWriteException(
-                            "Invalid record value, not ISO-8859-1");
+                /**
+                 * favor raw bytes over value. This allows callers to use their
+                 * own encoding of fields.
+                 */
+                final byte[] recordData;
+                if( element.getRawBytes() != null && element.getRawBytes().length > 0 ) {
+                    recordData = element.value.getBytes();
+                }
+                else {
+                    recordData = element.value.getBytes("ISO-8859-1");
+                    if (!new String(recordData, "ISO-8859-1").equals(element.value)) {
+                        throw new ImageWriteException(
+                                "Invalid record value, not ISO-8859-1");
+                    }
                 }
 
                 bos.write2Bytes(recordData.length);


### PR DESCRIPTION
The IPTCRecord supports a String value and raw bytes. When writing an IPTCRecord into the file the raw bytes are ignored and the string value is used only instead. This value is encoded in charset 8859-1. There is currently now way to use a different encoding then 8859-1.

The given change now uses the raw bytes if existent. if not then if falls back to the previous strategy (string value encoded as 8859-1)

My context:I am currently working on handling of IIM and XMP metadata in images and i need the capability to use a encoding different from 8859 im IIM. I would be happy to hear your opinions on the proposal.