### PR TITLE
Imaging-163

### DIFF
--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging;
 

--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging;
 
@@ -671,7 +673,11 @@ public abstract class ImageParser extends BinaryFileParser {
      * image content.  Not all image formats support EXP infomation and
      * even for those that do, there is no guarantee that such information
      * will be present in an image.
-     *
+     * <p>
+     * This is just a default implementation. It merely returns {@code null}.
+     * If an implementation can return something else than {@code null} please
+     * feel free to override this method. Vice versa, returning {@code null} 
+     * is the default behavior for implementing classes. See issue IMAGING-163.
      * @param byteSource A valid reference to a ByteSource.
      * @param params     Optional instructions for special-handling or
      *                   interpretation of the input data.
@@ -682,8 +688,10 @@ public abstract class ImageParser extends BinaryFileParser {
      *                            parser implementation.
      * @throws IOException        In the event of unsuccessful read or access operation.
      */
-    public abstract String getXmpXml(ByteSource byteSource, Map<String, Object> params)
-            throws ImageReadException, IOException;
+    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
+            throws ImageReadException, IOException {
+        return null;
+    }
 
     /**
      * Get an array of bytes describing the International Color Consortium (ICC)

--- a/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.bmp;
 
@@ -801,21 +803,4 @@ public class BmpImageParser extends ImageParser {
         // write Image Data
         bos.write(imagedata);
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
-
 }

--- a/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.bmp;
 

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.dcx;
 

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.dcx;
 
@@ -253,21 +255,5 @@ public class DcxImageParser extends ImageParser {
         }
         final PcxImageParser pcxImageParser = new PcxImageParser();
         pcxImageParser.writeImage(src, bos, pcxParams);
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.icns;
 
@@ -344,21 +346,5 @@ public class IcnsImageParser extends ImageParser {
             }
         }
         bos.close();
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.icns;
 

--- a/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.ico;
 

--- a/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.ico;
 
@@ -815,21 +817,5 @@ public class IcoImageParser extends ImageParser {
             }
         }
         bos.close();
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.pcx;
 
@@ -539,21 +541,5 @@ public class PcxImageParser extends ImageParser {
     public void writeImage(final BufferedImage src, final OutputStream os, final Map<String, Object> params)
             throws ImageWriteException, IOException {
         new PcxWriter(params).writeImage(src, os);
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.pcx;
 

--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.pnm;
 
@@ -362,21 +364,5 @@ public class PnmImageParser extends ImageParser {
         }
 
         writer.writeImage(src, os, params);
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.pnm;
 

--- a/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.rgbe;
 
@@ -147,12 +149,6 @@ public class RgbeImageParser extends ImageParser {
 
     @Override
     public byte[] getICCProfileBytes(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
-
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
             throws ImageReadException, IOException {
         return null;
     }

--- a/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 package org.apache.commons.imaging.formats.rgbe;
 

--- a/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
@@ -11,6 +11,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *  under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.wbmp;
@@ -274,21 +276,5 @@ public class WbmpImageParser extends ImageParser {
                 os.write(pixel);
             }
         }
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
@@ -11,8 +11,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *  under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.wbmp;

--- a/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
@@ -11,6 +11,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *  under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.xbm;
@@ -393,21 +395,5 @@ public class XbmImageParser extends ImageParser {
         }
 
         os.write("\n};\n".getBytes("US-ASCII"));
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
@@ -11,8 +11,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *  under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.xbm;

--- a/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
@@ -10,7 +10,8 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *  under the License.
+ *
+ * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.xpm;
@@ -730,21 +731,5 @@ public class XpmImageParser extends ImageParser {
 
         line = "\n};\n";
         os.write(line.getBytes("US-ASCII"));
-    }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     * 
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
@@ -10,8 +10,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * Changed 2015 by Michael Gross, mgmechanics@mgmechanics.de
  */
 
 package org.apache.commons.imaging.formats.xpm;


### PR DESCRIPTION
Patch for Imaging-163. I replaced the abstract method by a concrete one establish returnin g null as a default behaviour if not implemented otherwise. Returning null was already found as default behaviour.
