### PR TITLE
Fix header parse bug in PnmImageParser.

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -101,8 +101,18 @@ public class PnmImageParser extends ImageParser {
                 || identifier2 == PnmConstants.PPM_TEXT_CODE
                 || identifier2 == PnmConstants.PPM_RAW_CODE) {
             
-            final int width = Integer.parseInt(wsr.readtoWhiteSpace());
-            final int height = Integer.parseInt(wsr.readtoWhiteSpace());
+            final int width;
+            try {
+              width = Integer.parseInt(wsr.readtoWhiteSpace());
+            } catch (NumberFormatException e) {
+              throw new ImageReadException("Invalid width specified." , e);
+            }
+            final int height;
+            try {
+              height = Integer.parseInt(wsr.readtoWhiteSpace());
+            } catch (NumberFormatException e) {
+              throw new ImageReadException("Invalid height specified." , e);
+            }
     
             if (identifier2 == PnmConstants.PBM_TEXT_CODE) {
                 return new PbmFileInfo(width, height, false);

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
@@ -1,0 +1,47 @@
+package org.apache.commons.imaging.formats.pnm;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.imaging.ImageInfo;
+import org.apache.commons.imaging.ImageReadException;
+import org.junit.Test;
+
+public class PnmImageParserTest {
+
+  @Test
+  public void testGetImageInfo_happyCase() throws ImageReadException, IOException {
+    byte[] bytes = "P1\n3 2\n0 1 0\n1 0 1\n".getBytes(StandardCharsets.US_ASCII);
+    Map<String, Object> params = Collections.emptyMap();
+    PnmImageParser underTest = new PnmImageParser();
+    ImageInfo results = underTest.getImageInfo(bytes, params);
+    assertEquals(results.getBitsPerPixel(), 1);
+    assertEquals(results.getWidth(), 3);
+    assertEquals(results.getHeight(), 2);
+    assertEquals(results.getNumberOfImages(), 1);
+  }
+
+  /**
+   * If an invalid width is specified, should throw {@link ImageReadException} rather than
+   * {@link NumberFormatException}.
+   */
+  @Test(expected = ImageReadException.class)
+  public void testGetImageInfo_invalidWidth() throws ImageReadException, IOException {
+    byte[] bytes = "P1\na 2\n0 0 0 0 0 0 0 0 0 0 0\n1 1 1 1 1 1 1 1 1 1 1\n".getBytes(StandardCharsets.US_ASCII);
+    Map<String, Object> params = Collections.emptyMap();
+    PnmImageParser underTest = new PnmImageParser();
+    underTest.getImageInfo(bytes, params);
+  }
+
+  @Test(expected = ImageReadException.class)
+  public void testGetImageInfo_invalidHeight() throws ImageReadException, IOException {
+    byte[] bytes = "P1\n2 a\n0 0\n0 0\n0 0\n0 0\n0 0\n0 1\n1 1\n1 1\n1 1\n1 1\n1 1\n".getBytes(StandardCharsets.US_ASCII);
+    Map<String, Object> params = Collections.emptyMap();
+    PnmImageParser underTest = new PnmImageParser();
+    underTest.getImageInfo(bytes, params);
+  }
+}


### PR DESCRIPTION
Prior to this commit, PnmImagePArser would throw
NumberFormatException if the width or header could not be parsed.
Now it throws ImageReadException to be more consisten with the
rest of the commons-imaging API.