### PR TITLE
IMAGING-178 PnmImageParser does not check the validity of input pam header

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -157,18 +157,28 @@ public class PnmImageParser extends ImageParser {
                 final String type = tokenizer.nextToken();
                 if ("WIDTH".equals(type)) {
                     seenWidth = true;
+                    if(!tokenizer.hasMoreTokens())
+                        throw new ImageReadException("PAM header has no WIDTH value");
                     width = Integer.parseInt(tokenizer.nextToken());
                 } else if ("HEIGHT".equals(type)) {
                     seenHeight = true;
+                    if(!tokenizer.hasMoreTokens())
+                        throw new ImageReadException("PAM header has no HEIGHT value");
                     height = Integer.parseInt(tokenizer.nextToken());
                 } else if ("DEPTH".equals(type)) {
                     seenDepth = true;
+                    if(!tokenizer.hasMoreTokens())
+                        throw new ImageReadException("PAM header has no DEPTH value");
                     depth = Integer.parseInt(tokenizer.nextToken());
                 } else if ("MAXVAL".equals(type)) {
                     seenMaxVal = true;
+                    if(!tokenizer.hasMoreTokens())
+                        throw new ImageReadException("PAM header has no MAXVAL value");
                     maxVal = Integer.parseInt(tokenizer.nextToken());
                 } else if ("TUPLTYPE".equals(type)) {
                     seenTupleType = true;
+                    if(!tokenizer.hasMoreTokens())
+                        throw new ImageReadException("PAM header has no TUPLTYPE value");
                     tupleType.append(tokenizer.nextToken());
                 } else if ("ENDHDR".equals(type)) {
                     break;

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
@@ -46,4 +46,12 @@ public class PnmImageParserTest {
     PnmImageParser underTest = new PnmImageParser();
     underTest.getImageInfo(bytes, params);
   }
+
+  @Test(expected = ImageReadException.class)
+  public void testGetImageInfo_missingWidthValue() throws ImageReadException, IOException {
+    byte[] bytes = "P7\nWIDTH \n".getBytes(US_ASCII);
+    Map<String, Object> params = Collections.emptyMap();
+    PnmImageParser underTest = new PnmImageParser();
+    underTest.getImageInfo(bytes, params);
+  }
 }


### PR DESCRIPTION
PnmImageParser.java directly calls `tokenizer.nextToken()` on `java.util.StringTokenizer tokenizer` without checking if there are more tokens.  Because `tokenizer` is built from the bytes string
that can be invalid, this can lead to a runtime exception without a useful error message. 
This pull request adds an error messages and a test. 
Kindly let me know if you want me to change the messages and add more tests.