### PR TITLE
IMAGING-106: support for JPEG2000 and larger icons up to 1024px

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,400 +17,404 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <!-- ====================================================================== -->
-  <!-- P R O J E C T  D E S C R I P T I O N                                   -->
-  <!-- ====================================================================== -->
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T  D E S C R I P T I O N                                   -->
+    <!-- ====================================================================== -->
 
-  <parent>
+    <parent>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-parent</artifactId>
+        <version>40</version>
+    </parent>
+
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-parent</artifactId>
-    <version>40</version>
-  </parent>
+    <artifactId>commons-imaging</artifactId>
+    <name>Apache Commons Imaging</name>
 
-  <groupId>org.apache.commons</groupId>
-  <artifactId>commons-imaging</artifactId>
-  <name>Apache Commons Imaging</name>
+    <version>1.0-SNAPSHOT</version>
 
-  <version>1.0-SNAPSHOT</version>
+    <!--
+      Keep the description on a single line. Otherwise Maven might generate
+      a corrupted MANIFEST.MF (see http://jira.codehaus.org/browse/MJAR-4)
+     -->
+    <description>Apache Commons Imaging (previously Sanselan) is a pure-Java image library.</description>
+    <url>http://commons.apache.org/proper/commons-imaging/</url>
 
-  <!--
-    Keep the description on a single line. Otherwise Maven might generate
-    a corrupted MANIFEST.MF (see http://jira.codehaus.org/browse/MJAR-4)
-   -->
-  <description>Apache Commons Imaging (previously Sanselan) is a pure-Java image library.</description>
-  <url>http://commons.apache.org/proper/commons-imaging/</url>
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <commons.componentid>imaging</commons.componentid>
+        <commons.release.version>1.0</commons.release.version>
+        <commons.rc.version>RC5</commons.rc.version>
+        <commons.jira.id>IMAGING</commons.jira.id>
+        <commons.jira.pid>12313421</commons.jira.pid>
+        <commons.osgi.export>org.apache.commons.imaging.*;version=${project.version};-noimport:=true</commons.osgi.export>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
-  <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <commons.componentid>imaging</commons.componentid>
-    <commons.release.version>1.0</commons.release.version>
-    <commons.rc.version>RC5</commons.rc.version>
-    <commons.jira.id>IMAGING</commons.jira.id>
-    <commons.jira.pid>12313421</commons.jira.pid>
-    <commons.osgi.export>org.apache.commons.imaging.*;version=${project.version};-noimport:=true</commons.osgi.export>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
+    <scm>
+        <connection>scm:svn:http://svn.apache.org/repos/asf/commons/proper/imaging/trunk</connection>
+        <developerConnection>scm:svn:https://svn.apache.org/repos/asf/commons/proper/imaging/trunk</developerConnection>
+        <url>http://svn.apache.org/viewvc/commons/proper/imaging/trunk</url>
+    </scm>
 
-  <scm>
-    <connection>scm:svn:http://svn.apache.org/repos/asf/commons/proper/imaging/trunk</connection>
-    <developerConnection>scm:svn:https://svn.apache.org/repos/asf/commons/proper/imaging/trunk</developerConnection>
-    <url>http://svn.apache.org/viewvc/commons/proper/imaging/trunk</url>
-  </scm>
+    <distributionManagement>
+        <site>
+            <id>stagingSite</id>
+            <name>Apache Staging Website</name>
+            <url>${commons.deployment.protocol}://people.apache.org/www/commons.apache.org/${commons.componentid}/</url>
+        </site>
+    </distributionManagement>
 
-  <distributionManagement>
-    <site>
-      <id>stagingSite</id>
-      <name>Apache Staging Website</name>
-      <url>${commons.deployment.protocol}://people.apache.org/www/commons.apache.org/${commons.componentid}/</url>
-    </site>
-  </distributionManagement>
+    <issueManagement>
+        <system>Jira</system>
+        <url>http://issues.apache.org/jira/browse/IMAGING</url>
+    </issueManagement>
+    <inceptionYear>2007</inceptionYear>
 
-  <issueManagement>
-    <system>Jira</system>
-    <url>http://issues.apache.org/jira/browse/IMAGING</url>
-  </issueManagement>
-  <inceptionYear>2007</inceptionYear>
+    <prerequisites>
+        <maven>2.0.7</maven>
+    </prerequisites>
 
-  <prerequisites>
-    <maven>2.0.7</maven>
-  </prerequisites>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptors>
-            <descriptor>src/assembly/bin.xml</descriptor>
-            <descriptor>src/assembly/src.xml</descriptor>
-          </descriptors>
-          <tarLongFileMode>gnu</tarLongFileMode>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Extension-Name>org.apache.commons.imaging</Extension-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check-java-api</id>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-scm-publish-plugin</artifactId>
-          <configuration>
-            <ignorePathsToDelete>
-              <ignorePathToDelete>javadocs**</ignorePathToDelete>
-            </ignorePathsToDelete>
-          </configuration>
-        </plugin>     
-        <!-- This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/bin.xml</descriptor>
+                        <descriptor>src/assembly/src.xml</descriptor>
+                    </descriptors>
+                    <tarLongFileMode>gnu</tarLongFileMode>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Extension-Name>org.apache.commons.imaging</Extension-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.15</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java17</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-java-api</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <versionRange>[1.6,)</versionRange>
-                    <goals>
-                      <goal>run</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <versionRange>[2.3.5,)</versionRange>
-                    <goals>
-                      <goal>manifest</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <excludePackageNames>org.apache.commons.imaging.formats.psd.*:org.apache.commons.imaging.formats.png.*</excludePackageNames>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <configuration>
+                        <ignorePathsToDelete>
+                            <ignorePathToDelete>javadocs**</ignorePathToDelete>
+                        </ignorePathsToDelete>
+                    </configuration>
+                </plugin>
+                <!-- This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[1.6,)</versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.felix</groupId>
+                                        <artifactId>maven-bundle-plugin</artifactId>
+                                        <versionRange>[2.3.5,)</versionRange>
+                                        <goals>
+                                            <goal>manifest</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <excludePackageNames>org.apache.commons.imaging.formats.psd.*:org.apache.commons.imaging.formats.png.*</excludePackageNames>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+    </dependencies>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
-        <configuration>
-          <threshold>Normal</threshold>
-          <effort>Default</effort>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>javancss-maven-plugin</artifactId>
-        <version>2.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-changes-plugin</artifactId>
-        <version>${commons.changes.version}</version>
-        <configuration>
-          <issueLinkTemplate>%URL%/%ISSUE%</issueLinkTemplate>
-        </configuration>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>changes-report</report>
-              <report>jira-report</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.11</version>
-        <inherited>false</inherited>
-        <configuration>
-          <configLocation>${basedir}/src/conf/checkstyle.xml</configLocation>
-          <suppressionsLocation>${basedir}/src/conf/checkstyle-suppressions.xml</suppressionsLocation>
-          <enableRulesSummary>false</enableRulesSummary>
-          <propertyExpansion>basedir=${basedir}</propertyExpansion>
-        </configuration>
-        <!-- Work around CHECKSTYLE-172 -->
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>checkstyle</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <targetJdk>${maven.compiler.target}</targetJdk>
-          <rulesets>
-            <ruleset>${basedir}/src/conf/pmd-ruleset.xml</ruleset>
-          </rulesets>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>taglist-maven-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <tagListOptions>
-            <tagClasses>
-              <tagClass>
-                <displayName>Needs Work</displayName>
-                <tags>
-                  <tag>
-                    <matchString>TODO</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                  <tag>
-                    <matchString>FIXME</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                  <tag>
-                    <matchString>XXX</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                </tags>
-              </tagClass>
-              <tagClass>
-                <displayName>Noteable Markers</displayName>
-                <tags>
-                  <tag>
-                    <matchString>NOTE</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                  <tag>
-                    <matchString>NOPMD</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                  <tag>
-                    <matchString>NOSONAR</matchString>
-                    <matchType>exact</matchType>
-                  </tag>
-                </tags>
-              </tagClass>
-            </tagClasses>
-          </tagListOptions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/test/data/images/xpm/1/symbolic.xpm</exclude>
-            <exclude>src/test/data/images/xpm/1/Oregon Scientific DS6639 - DSC_0307 - small.xpm</exclude>
-            <exclude>src/test/data/images/pbm/2/5x5-grayscale.pam</exclude>
-            <exclude>src/test/data/images/pbm/2/5x5-bw.pam</exclude>
-            <exclude>src/test/data/images/pbm/1/Oregon Scientific DS6639 - DSC_0307 - small.pgm</exclude>
-            <exclude>src/test/data/images/xbm/1/Oregon Scientific DS6639 - DSC_0307 - small.xbm</exclude>
-            <exclude>src/main/resources/org/apache/commons/imaging/formats/xpm/rgb.txt</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.3</version>
+                <configuration>
+                    <threshold>Normal</threshold>
+                    <effort>Default</effort>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javancss-maven-plugin</artifactId>
+                <version>2.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changes-plugin</artifactId>
+                <version>${commons.changes.version}</version>
+                <configuration>
+                    <issueLinkTemplate>%URL%/%ISSUE%</issueLinkTemplate>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>changes-report</report>
+                            <report>jira-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.11</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <configLocation>${basedir}/src/conf/checkstyle.xml</configLocation>
+                    <suppressionsLocation>${basedir}/src/conf/checkstyle-suppressions.xml</suppressionsLocation>
+                    <enableRulesSummary>false</enableRulesSummary>
+                    <propertyExpansion>basedir=${basedir}</propertyExpansion>
+                </configuration>
+                <!-- Work around CHECKSTYLE-172 -->
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>checkstyle</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <targetJdk>${maven.compiler.target}</targetJdk>
+                    <rulesets>
+                        <ruleset>${basedir}/src/conf/pmd-ruleset.xml</ruleset>
+                    </rulesets>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <tagListOptions>
+                        <tagClasses>
+                            <tagClass>
+                                <displayName>Needs Work</displayName>
+                                <tags>
+                                    <tag>
+                                        <matchString>TODO</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>FIXME</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>XXX</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                </tags>
+                            </tagClass>
+                            <tagClass>
+                                <displayName>Noteable Markers</displayName>
+                                <tags>
+                                    <tag>
+                                        <matchString>NOTE</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>NOPMD</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>NOSONAR</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                </tags>
+                            </tagClass>
+                        </tagClasses>
+                    </tagListOptions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/test/data/images/xpm/1/symbolic.xpm</exclude>
+                        <exclude>src/test/data/images/xpm/1/Oregon Scientific DS6639 - DSC_0307 - small.xpm</exclude>
+                        <exclude>src/test/data/images/pbm/2/5x5-grayscale.pam</exclude>
+                        <exclude>src/test/data/images/pbm/2/5x5-bw.pam</exclude>
+                        <exclude>src/test/data/images/pbm/1/Oregon Scientific DS6639 - DSC_0307 - small.pgm</exclude>
+                        <exclude>src/test/data/images/xbm/1/Oregon Scientific DS6639 - DSC_0307 - small.xbm</exclude>
+                        <exclude>src/main/resources/org/apache/commons/imaging/formats/xpm/rgb.txt</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
-  <profiles>
-    <profile>
-      <id>jdk8-javadoc</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <additionalparam>-Xdoclint:none</additionalparam>
-      </properties>
-    </profile>
-  </profiles>
+    <profiles>
+        <profile>
+            <id>jdk8-javadoc</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+    </profiles>
 
-  <!-- ====================================================================== -->
-  <!-- P E O P L E                                                            -->
-  <!-- ====================================================================== -->
+    <!-- ====================================================================== -->
+    <!-- P E O P L E                                                            -->
+    <!-- ====================================================================== -->
 
-  <developers>
-    <developer>
-      <name>Charles M. Chen</name>
-      <id>cmchen</id>
-    </developer>
-    <developer>
-      <name>Philipp Koch</name>
-      <id>pkoch</id>
-    </developer>
-    <developer>
-      <name>Jeremias Maerki</name>
-      <id>jeremias</id>
-    </developer>
-    <developer>
-      <name>Craig Russell</name>
-      <id>clr</id>
-    </developer>
-    <developer>
-      <name>Yoav Shapira</name>
-      <id>yoavs</id>
-    </developer>
-    <developer>
-      <name>Carsten Ziegeler</name>
-      <id>cziegeler</id>
-    </developer>
-    <developer>
-      <name>Damjan Jovanovic</name>
-      <id>damjan</id>
-    </developer>
-    <developer>
-      <name>Matt Benson</name>
-      <id>mbenson</id>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <name>Charles M. Chen</name>
+            <id>cmchen</id>
+        </developer>
+        <developer>
+            <name>Philipp Koch</name>
+            <id>pkoch</id>
+        </developer>
+        <developer>
+            <name>Jeremias Maerki</name>
+            <id>jeremias</id>
+        </developer>
+        <developer>
+            <name>Craig Russell</name>
+            <id>clr</id>
+        </developer>
+        <developer>
+            <name>Yoav Shapira</name>
+            <id>yoavs</id>
+        </developer>
+        <developer>
+            <name>Carsten Ziegeler</name>
+            <id>cziegeler</id>
+        </developer>
+        <developer>
+            <name>Damjan Jovanovic</name>
+            <id>damjan</id>
+        </developer>
+        <developer>
+            <name>Matt Benson</name>
+            <id>mbenson</id>
+        </developer>
+    </developers>
 
-  <contributors>
-    <contributor>
-      <name>Adrian Moerchen</name>
-    </contributor>
-    <contributor>
-      <name>Alex Vigdor</name>
-    </contributor>
-    <contributor>
-      <name>Craig Kelly</name>
-    </contributor>
-    <contributor>
-      <name>Gary Lucas</name>
-    </contributor>
-    <contributor>
-      <name>Gavin Shiels</name>
-    </contributor>
-    <contributor>
-      <name>Peter Royal</name>
-    </contributor>
-    <contributor>
-      <name>Piyush Kapoor</name>
-    </contributor>
-    <contributor>
-      <name>Tars Joris</name>
-    </contributor>
-    <contributor>
-      <name>VVD</name>
-    </contributor>
-  </contributors>
+    <contributors>
+        <contributor>
+            <name>Adrian Moerchen</name>
+        </contributor>
+        <contributor>
+            <name>Alex Vigdor</name>
+        </contributor>
+        <contributor>
+            <name>Craig Kelly</name>
+        </contributor>
+        <contributor>
+            <name>Gary Lucas</name>
+        </contributor>
+        <contributor>
+            <name>Gavin Shiels</name>
+        </contributor>
+        <contributor>
+            <name>Peter Royal</name>
+        </contributor>
+        <contributor>
+            <name>Piyush Kapoor</name>
+        </contributor>
+        <contributor>
+            <name>Tars Joris</name>
+        </contributor>
+        <contributor>
+            <name>VVD</name>
+        </contributor>
+    </contributors>
 </project>

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsDecoder.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsDecoder.java
@@ -17,71 +17,24 @@
 package org.apache.commons.imaging.formats.icns;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.formats.icns.IcnsImageParser.IcnsElement;
 
 final class IcnsDecoder {
-    private static final int[] PALETTE_4BPP = { 0xffffffff, 0xfffcf305,
-            0xffff6402, 0xffdd0806, 0xfff20884, 0xff4600a5, 0xff0000d4,
-            0xff02abea, 0xff1fb714, 0xff006411, 0xff562c05, 0xff90713a,
-            0xffc0c0c0, 0xff808080, 0xff404040, 0xff000000 };
+    private static final int[] PALETTE_4BPP = { 0xffffffff, 0xfffcf305, 0xffff6402, 0xffdd0806, 0xfff20884, 0xff4600a5, 0xff0000d4, 0xff02abea, 0xff1fb714, 0xff006411, 0xff562c05, 0xff90713a, 0xffc0c0c0, 0xff808080, 0xff404040, 0xff000000 };
 
-    private static final int[] PALETTE_8BPP = { 0xFFFFFFFF, 0xFFFFFFCC,
-            0xFFFFFF99, 0xFFFFFF66, 0xFFFFFF33, 0xFFFFFF00, 0xFFFFCCFF,
-            0xFFFFCCCC, 0xFFFFCC99, 0xFFFFCC66, 0xFFFFCC33, 0xFFFFCC00,
-            0xFFFF99FF, 0xFFFF99CC, 0xFFFF9999, 0xFFFF9966, 0xFFFF9933,
-            0xFFFF9900, 0xFFFF66FF, 0xFFFF66CC, 0xFFFF6699, 0xFFFF6666,
-            0xFFFF6633, 0xFFFF6600, 0xFFFF33FF, 0xFFFF33CC, 0xFFFF3399,
-            0xFFFF3366, 0xFFFF3333, 0xFFFF3300, 0xFFFF00FF, 0xFFFF00CC,
-            0xFFFF0099, 0xFFFF0066, 0xFFFF0033, 0xFFFF0000, 0xFFCCFFFF,
-            0xFFCCFFCC, 0xFFCCFF99, 0xFFCCFF66, 0xFFCCFF33, 0xFFCCFF00,
-            0xFFCCCCFF, 0xFFCCCCCC, 0xFFCCCC99, 0xFFCCCC66, 0xFFCCCC33,
-            0xFFCCCC00, 0xFFCC99FF, 0xFFCC99CC, 0xFFCC9999, 0xFFCC9966,
-            0xFFCC9933, 0xFFCC9900, 0xFFCC66FF, 0xFFCC66CC, 0xFFCC6699,
-            0xFFCC6666, 0xFFCC6633, 0xFFCC6600, 0xFFCC33FF, 0xFFCC33CC,
-            0xFFCC3399, 0xFFCC3366, 0xFFCC3333, 0xFFCC3300, 0xFFCC00FF,
-            0xFFCC00CC, 0xFFCC0099, 0xFFCC0066, 0xFFCC0033, 0xFFCC0000,
-            0xFF99FFFF, 0xFF99FFCC, 0xFF99FF99, 0xFF99FF66, 0xFF99FF33,
-            0xFF99FF00, 0xFF99CCFF, 0xFF99CCCC, 0xFF99CC99, 0xFF99CC66,
-            0xFF99CC33, 0xFF99CC00, 0xFF9999FF, 0xFF9999CC, 0xFF999999,
-            0xFF999966, 0xFF999933, 0xFF999900, 0xFF9966FF, 0xFF9966CC,
-            0xFF996699, 0xFF996666, 0xFF996633, 0xFF996600, 0xFF9933FF,
-            0xFF9933CC, 0xFF993399, 0xFF993366, 0xFF993333, 0xFF993300,
-            0xFF9900FF, 0xFF9900CC, 0xFF990099, 0xFF990066, 0xFF990033,
-            0xFF990000, 0xFF66FFFF, 0xFF66FFCC, 0xFF66FF99, 0xFF66FF66,
-            0xFF66FF33, 0xFF66FF00, 0xFF66CCFF, 0xFF66CCCC, 0xFF66CC99,
-            0xFF66CC66, 0xFF66CC33, 0xFF66CC00, 0xFF6699FF, 0xFF6699CC,
-            0xFF669999, 0xFF669966, 0xFF669933, 0xFF669900, 0xFF6666FF,
-            0xFF6666CC, 0xFF666699, 0xFF666666, 0xFF666633, 0xFF666600,
-            0xFF6633FF, 0xFF6633CC, 0xFF663399, 0xFF663366, 0xFF663333,
-            0xFF663300, 0xFF6600FF, 0xFF6600CC, 0xFF660099, 0xFF660066,
-            0xFF660033, 0xFF660000, 0xFF33FFFF, 0xFF33FFCC, 0xFF33FF99,
-            0xFF33FF66, 0xFF33FF33, 0xFF33FF00, 0xFF33CCFF, 0xFF33CCCC,
-            0xFF33CC99, 0xFF33CC66, 0xFF33CC33, 0xFF33CC00, 0xFF3399FF,
-            0xFF3399CC, 0xFF339999, 0xFF339966, 0xFF339933, 0xFF339900,
-            0xFF3366FF, 0xFF3366CC, 0xFF336699, 0xFF336666, 0xFF336633,
-            0xFF336600, 0xFF3333FF, 0xFF3333CC, 0xFF333399, 0xFF333366,
-            0xFF333333, 0xFF333300, 0xFF3300FF, 0xFF3300CC, 0xFF330099,
-            0xFF330066, 0xFF330033, 0xFF330000, 0xFF00FFFF, 0xFF00FFCC,
-            0xFF00FF99, 0xFF00FF66, 0xFF00FF33, 0xFF00FF00, 0xFF00CCFF,
-            0xFF00CCCC, 0xFF00CC99, 0xFF00CC66, 0xFF00CC33, 0xFF00CC00,
-            0xFF0099FF, 0xFF0099CC, 0xFF009999, 0xFF009966, 0xFF009933,
-            0xFF009900, 0xFF0066FF, 0xFF0066CC, 0xFF006699, 0xFF006666,
-            0xFF006633, 0xFF006600, 0xFF0033FF, 0xFF0033CC, 0xFF003399,
-            0xFF003366, 0xFF003333, 0xFF003300, 0xFF0000FF, 0xFF0000CC,
-            0xFF000099, 0xFF000066, 0xFF000033, 0xFFEE0000, 0xFFDD0000,
-            0xFFBB0000, 0xFFAA0000, 0xFF880000, 0xFF770000, 0xFF550000,
-            0xFF440000, 0xFF220000, 0xFF110000, 0xFF00EE00, 0xFF00DD00,
-            0xFF00BB00, 0xFF00AA00, 0xFF008800, 0xFF007700, 0xFF005500,
-            0xFF004400, 0xFF002200, 0xFF001100, 0xFF0000EE, 0xFF0000DD,
-            0xFF0000BB, 0xFF0000AA, 0xFF000088, 0xFF000077, 0xFF000055,
-            0xFF000044, 0xFF000022, 0xFF000011, 0xFFEEEEEE, 0xFFDDDDDD,
-            0xFFBBBBBB, 0xFFAAAAAA, 0xFF888888, 0xFF777777, 0xFF555555,
-            0xFF444444, 0xFF222222, 0xFF111111, 0xFF000000 };
+    private static final int[] PALETTE_8BPP = { 0xFFFFFFFF, 0xFFFFFFCC, 0xFFFFFF99, 0xFFFFFF66, 0xFFFFFF33, 0xFFFFFF00, 0xFFFFCCFF, 0xFFFFCCCC, 0xFFFFCC99, 0xFFFFCC66, 0xFFFFCC33, 0xFFFFCC00, 0xFFFF99FF, 0xFFFF99CC, 0xFFFF9999, 0xFFFF9966, 0xFFFF9933, 0xFFFF9900, 0xFFFF66FF, 0xFFFF66CC, 0xFFFF6699, 0xFFFF6666, 0xFFFF6633, 0xFFFF6600, 0xFFFF33FF, 0xFFFF33CC, 0xFFFF3399, 0xFFFF3366, 0xFFFF3333, 0xFFFF3300, 0xFFFF00FF, 0xFFFF00CC, 0xFFFF0099, 0xFFFF0066, 0xFFFF0033, 0xFFFF0000, 0xFFCCFFFF, 0xFFCCFFCC, 0xFFCCFF99, 0xFFCCFF66, 0xFFCCFF33, 0xFFCCFF00, 0xFFCCCCFF, 0xFFCCCCCC, 0xFFCCCC99, 0xFFCCCC66, 0xFFCCCC33, 0xFFCCCC00, 0xFFCC99FF, 0xFFCC99CC, 0xFFCC9999, 0xFFCC9966, 0xFFCC9933, 0xFFCC9900, 0xFFCC66FF, 0xFFCC66CC, 0xFFCC6699, 0xFFCC6666, 0xFFCC6633, 0xFFCC6600, 0xFFCC33FF, 0xFFCC33CC, 0xFFCC3399, 0xFFCC3366, 0xFFCC3333, 0xFFCC3300, 0xFFCC00FF, 0xFFCC00CC, 0xFFCC0099, 0xFFCC0066, 0xFFCC0033, 0xFFCC0000, 0xFF99FFFF, 0xFF99FFCC, 0xFF99FF99, 0xFF99FF66, 0xFF99FF33, 0xFF99FF00, 0xFF99CCFF, 0xFF99CCCC, 0xFF99CC99, 0xFF99CC66, 0xFF99CC33, 0xFF99CC00, 0xFF9999FF, 0xFF9999CC, 0xFF999999, 0xFF999966, 0xFF999933, 0xFF999900, 0xFF9966FF, 0xFF9966CC, 0xFF996699, 0xFF996666, 0xFF996633, 0xFF996600, 0xFF9933FF, 0xFF9933CC, 0xFF993399, 0xFF993366, 0xFF993333, 0xFF993300, 0xFF9900FF, 0xFF9900CC, 0xFF990099, 0xFF990066, 0xFF990033, 0xFF990000, 0xFF66FFFF, 0xFF66FFCC, 0xFF66FF99, 0xFF66FF66, 0xFF66FF33, 0xFF66FF00, 0xFF66CCFF, 0xFF66CCCC, 0xFF66CC99, 0xFF66CC66, 0xFF66CC33, 0xFF66CC00, 0xFF6699FF, 0xFF6699CC, 0xFF669999, 0xFF669966, 0xFF669933, 0xFF669900, 0xFF6666FF, 0xFF6666CC, 0xFF666699, 0xFF666666, 0xFF666633, 0xFF666600, 0xFF6633FF, 0xFF6633CC, 0xFF663399, 0xFF663366, 0xFF663333, 0xFF663300, 0xFF6600FF, 0xFF6600CC, 0xFF660099, 0xFF660066, 0xFF660033, 0xFF660000, 0xFF33FFFF, 0xFF33FFCC, 0xFF33FF99, 0xFF33FF66, 0xFF33FF33, 0xFF33FF00, 0xFF33CCFF, 0xFF33CCCC, 0xFF33CC99, 0xFF33CC66, 0xFF33CC33, 0xFF33CC00, 0xFF3399FF, 0xFF3399CC, 0xFF339999, 0xFF339966, 0xFF339933, 0xFF339900, 0xFF3366FF, 0xFF3366CC, 0xFF336699, 0xFF336666, 0xFF336633, 0xFF336600, 0xFF3333FF, 0xFF3333CC, 0xFF333399, 0xFF333366, 0xFF333333, 0xFF333300, 0xFF3300FF, 0xFF3300CC, 0xFF330099, 0xFF330066, 0xFF330033, 0xFF330000, 0xFF00FFFF, 0xFF00FFCC, 0xFF00FF99, 0xFF00FF66, 0xFF00FF33, 0xFF00FF00, 0xFF00CCFF, 0xFF00CCCC, 0xFF00CC99, 0xFF00CC66, 0xFF00CC33, 0xFF00CC00, 0xFF0099FF, 0xFF0099CC, 0xFF009999, 0xFF009966, 0xFF009933, 0xFF009900, 0xFF0066FF, 0xFF0066CC, 0xFF006699, 0xFF006666, 0xFF006633, 0xFF006600, 0xFF0033FF, 0xFF0033CC, 0xFF003399, 0xFF003366, 0xFF003333, 0xFF003300, 0xFF0000FF, 0xFF0000CC, 0xFF000099, 0xFF000066, 0xFF000033, 0xFFEE0000, 0xFFDD0000, 0xFFBB0000, 0xFFAA0000, 0xFF880000, 0xFF770000, 0xFF550000, 0xFF440000, 0xFF220000, 0xFF110000, 0xFF00EE00, 0xFF00DD00, 0xFF00BB00, 0xFF00AA00, 0xFF008800, 0xFF007700, 0xFF005500, 0xFF004400, 0xFF002200, 0xFF001100, 0xFF0000EE, 0xFF0000DD, 0xFF0000BB, 0xFF0000AA, 0xFF000088, 0xFF000077, 0xFF000055, 0xFF000044, 0xFF000022, 0xFF000011, 0xFFEEEEEE, 0xFFDDDDDD, 0xFFBBBBBB, 0xFFAAAAAA, 0xFF888888, 0xFF777777, 0xFF555555, 0xFF444444, 0xFF222222, 0xFF111111, 0xFF000000 };
 
     private IcnsDecoder() {
     }
@@ -96,7 +49,7 @@ final class IcnsDecoder {
                     value = 0xff & imageData[position++];
                     bitsLeft = 8;
                 }
-                int argb;
+                final int argb;
                 if ((value & 0x80) != 0) {
                     argb = 0xff000000;
                 } else {
@@ -114,7 +67,7 @@ final class IcnsDecoder {
         boolean visited = false;
         for (int y = 0; y < imageType.getHeight(); y++) {
             for (int x = 0; x < imageType.getWidth(); x++) {
-                int index;
+                final int index;
                 if (!visited) {
                     index = 0xf & (imageData[i] >> 4);
                 } else {
@@ -139,9 +92,9 @@ final class IcnsDecoder {
         for (int y = 0; y < imageType.getHeight(); y++) {
             for (int x = 0; x < imageType.getWidth(); x++) {
                 final int argb = 0xff000000 /* the "alpha" is ignored */
-                        | ((0xff & imageData[4 * (y * imageType.getWidth() + x) + 1]) << 16)
-                        | ((0xff & imageData[4 * (y * imageType.getWidth() + x) + 2]) << 8)
-                        | (0xff & imageData[4 * (y * imageType.getWidth() + x) + 3]);
+                    | ((0xff & imageData[4 * (y * imageType.getWidth() + x) + 1]) << 16)
+                    | ((0xff & imageData[4 * (y * imageType.getWidth() + x) + 2]) << 8)
+                    | (0xff & imageData[4 * (y * imageType.getWidth() + x) + 3]);
                 image.setRGB(x, y, argb);
             }
         }
@@ -167,7 +120,7 @@ final class IcnsDecoder {
                     value = 0xff & maskData[position++];
                     bitsLeft = 8;
                 }
-                int alpha;
+                final int alpha;
                 if ((value & 0x80) != 0) {
                     alpha = 0xff;
                 } else {
@@ -184,16 +137,16 @@ final class IcnsDecoder {
         for (int y = 0; y < image.getHeight(); y++) {
             for (int x = 0; x < image.getWidth(); x++) {
                 final int alpha = 0xff & maskData[y * image.getWidth() + x];
-                image.setRGB(x, y,
-                        (alpha << 24) | (0xffffff & image.getRGB(x, y)));
+                image.setRGB(x, y, (alpha << 24) | (0xffffff & image.getRGB(x, y)));
             }
         }
     }
 
-    public static List<BufferedImage> decodeAllImages(final IcnsImageParser.IcnsElement[] icnsElements)
-            throws ImageReadException {
-        final List<BufferedImage> result = new ArrayList<>();
+    public static List<Map<BufferedImage, IcnsType>> decodeAllImages(final IcnsImageParser.IcnsElement[] icnsElements) throws ImageReadException {
+        final List<Map<BufferedImage, IcnsType>> result = new ArrayList<>();
         for (final IcnsElement imageElement : icnsElements) {
+            final Map<BufferedImage, IcnsType> image = new HashMap<>();
+
             final IcnsType imageType = IcnsType.findImageType(imageElement.type);
             if (imageType == null) {
                 continue;
@@ -227,44 +180,59 @@ final class IcnsDecoder {
                 }
             }
 
-            // FIXME: don't skip these when JPEG 2000 support is added:
-            if (imageType == IcnsType.ICNS_256x256_32BIT_ARGB_IMAGE
-                    || imageType == IcnsType.ICNS_512x512_32BIT_ARGB_IMAGE) {
+            if (isPngImage(imageElement.data) || isJpeg2000Image(imageElement.data)) {
+                try {
+                    final InputStream in = new ByteArrayInputStream(imageElement.data);
+                    final BufferedImage bufferedImage = ImageIO.read(in);
+                    if (bufferedImage == null) {
+                        if (isPngImage(imageElement.data)) {
+                            System.out.println("Can not read PNG image. [" + imageType.getTypeName() + "]");
+                        }
+                        if (isJpeg2000Image(imageElement.data)) {
+                            System.out.println("Can not read Jpeg2000 image. [" + imageType.getTypeName() + "]");
+                        }
+                    } else {
+                        image.put(bufferedImage, imageType);
+                        result.add(image);
+                    }
+                } catch (final IOException e) {
+                    throw new ImageReadException(e.getMessage());
+                }
                 continue;
             }
 
-            final int expectedSize = (imageType.getWidth() * imageType.getHeight()
-                    * imageType.getBitsPerPixel() + 7) / 8;
-            byte[] imageData;
+            final int expectedSize = (imageType.getWidth()
+                * imageType.getHeight()
+                * imageType.getBitsPerPixel() + 7) / 8;
+            final byte[] imageData;
             if (imageElement.data.length < expectedSize) {
                 if (imageType.getBitsPerPixel() == 32) {
-                    imageData = Rle24Compression.decompress(
-                            imageType.getWidth(), imageType.getHeight(),
-                            imageElement.data);
+                    imageData = Rle24Compression.decompress(imageType.getWidth(), imageType.getHeight(), imageElement.data);
                 } else {
-                    throw new ImageReadException("Short image data but not a 32 bit compressed type");
+                    System.out.println("Short image data but not a 32 bit compressed type");
+                    continue;
                 }
             } else {
                 imageData = imageElement.data;
             }
 
-            final ImageBuilder imageBuilder = new ImageBuilder(imageType.getWidth(),
-                    imageType.getHeight(), true);
+            final ImageBuilder imageBuilder = new ImageBuilder(imageType.getWidth(), imageType.getHeight(), true);
             switch (imageType.getBitsPerPixel()) {
-            case 1:
-                decode1BPPImage(imageType, imageData, imageBuilder);
-                break;
-            case 4:
-                decode4BPPImage(imageType, imageData, imageBuilder);
-                break;
-            case 8:
-                decode8BPPImage(imageType, imageData, imageBuilder);
-                break;
-            case 32:
-                decode32BPPImage(imageType, imageData, imageBuilder);
-                break;
-            default:
-                throw new ImageReadException("Unsupported bit depth " + imageType.getBitsPerPixel());
+                case 1:
+                    decode1BPPImage(imageType, imageData, imageBuilder);
+                    break;
+                case 4:
+                    decode4BPPImage(imageType, imageData, imageBuilder);
+                    break;
+                case 8:
+                    decode8BPPImage(imageType, imageData, imageBuilder);
+                    break;
+                case 32:
+                    decode32BPPImage(imageType, imageData, imageBuilder);
+                    break;
+                default:
+                    System.out.println("Unsupported bit depth " + imageType.getBitsPerPixel());
+                    continue;
             }
 
             if (maskElement != null) {
@@ -273,12 +241,36 @@ final class IcnsDecoder {
                 } else if (maskType.getBitsPerPixel() == 8) {
                     apply8BPPMask(maskElement.data, imageBuilder);
                 } else {
-                    throw new ImageReadException("Unsupport mask bit depth " + maskType.getBitsPerPixel());
+                    System.out.println("Unsupport mask bit depth " + maskType.getBitsPerPixel());
+                    continue;
                 }
             }
-
-            result.add(imageBuilder.getBufferedImage());
+            image.put(imageBuilder.getBufferedImage(), imageType);
+            result.add(image);
         }
         return result;
+    }
+
+    private static boolean isPngImage(final byte[] data) {
+        if (data.length > 4) {
+            if ((char) data[1] == 'P' && (char) data[2] == 'N' && (char) data[3] == 'G') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isJpeg2000Image(final byte[] data) {
+        final String jpeg2000Signature = "0 0 0 12 106 80 32 32 13 10";
+        final StringBuilder stringBuilder = new StringBuilder();
+        if (data.length > 10) {
+            for (int i = 0; i < 10; i++) {
+                stringBuilder.append(String.valueOf(data[i]) + " ");
+            }
+            if (stringBuilder.toString().trim().equals(jpeg2000Signature)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsType.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsType.java
@@ -20,104 +20,88 @@ import java.io.UnsupportedEncodingException;
 
 enum IcnsType {
 
-    ICNS_16x12_1BIT_IMAGE_AND_MASK("icm#", 16, 12, 1, true),
-    ICNS_16x12_4BIT_IMAGE("icm4", 16, 12, 4, false),
-    ICNS_16x12_8BIT_IMAGE("icm8", 16, 12, 8, false),
+    ICNS_16x12_1BIT_IMAGE_AND_MASK("icm#", 16, 12, 1, true, false), ICNS_16x12_4BIT_IMAGE("icm4", 16, 12, 4, false, false), ICNS_16x12_8BIT_IMAGE("icm8", 16, 12, 8, false, false), ICNS_16x16_8BIT_MASK("s8mk", 16, 16, 8, true, false), ICNS_16x16_1BIT_IMAGE_AND_MASK("ics#", 16, 16, 1, true, false), ICNS_16x16_4BIT_IMAGE("ics4", 16, 16, 4, false, false), ICNS_16x16_8BIT_IMAGE("ics8", 16, 16, 8, false, false), ICNS_16x16_32BIT_IMAGE("is32", 16, 16, 32, false, false), ICNS_16x16_32BIT_ARGB_IMAGE("icp4", 16, 16, 32, false, true),
 
-    ICNS_16x16_8BIT_MASK("s8mk", 16, 16, 8, true),
-    ICNS_16x16_1BIT_IMAGE_AND_MASK("ics#", 16, 16, 1, true),
-    ICNS_16x16_4BIT_IMAGE("ics4", 16, 16, 4, false),
-    ICNS_16x16_8BIT_IMAGE("ics8", 16, 16, 8, false),
-    ICNS_16x16_32BIT_IMAGE("is32", 16, 16, 32, false),
+    ICNS_32x32_1BIT_MONO_IMAGE("ICON", 32, 32, 1, false, false), ICNS_32x32_1BIT_IMAGE_AND_MASK("ICN#", 32, 32, 1, true, false), ICNS_32x32_4BIT_IMAGE("icl4", 32, 32, 4, false, false), ICNS_32x32_8BIT_IMAGE("icl8", 32, 32, 8, false, false), ICNS_32x32_8BIT_MASK("l8mk", 32, 32, 8, true, false), ICNS_32x32_32BIT_IMAGE("il32", 32, 32, 32, false, false), ICNS_32x32_32BIT_ARGB_IMAGE("icp5", 32, 32, 32, false, true), ICNS_32x32_32BIT_RETINA_IMAGE("ic11", 32, 32, 32, false, true),
 
-    ICNS_32x32_8BIT_MASK("l8mk", 32, 32, 8, true),
-    ICNS_32x32_1BIT_IMAGE_AND_MASK("ICN#", 32, 32, 1, true),
-    ICNS_32x32_4BIT_IMAGE("icl4", 32, 32, 4, false),
-    ICNS_32x32_8BIT_IMAGE("icl8", 32, 32, 8, false),
-    ICNS_32x32_32BIT_IMAGE("il32", 32, 32, 32, false),
+    ICNS_48x48_1BIT_IMAGE_AND_MASK("ich#", 48, 48, 1, true, false), ICNS_48x48_4BIT_IMAGE("ich4", 48, 48, 4, false, false), ICNS_48x48_8BIT_IMAGE("ich8", 48, 48, 8, false, false), ICNS_48x48_8BIT_MASK("h8mk", 48, 48, 8, true, false), ICNS_48x48_32BIT_IMAGE("ih32", 48, 48, 32, false, false),
 
-    ICNS_48x48_8BIT_MASK("h8mk", 48, 48, 8, true),
-    ICNS_48x48_1BIT_IMAGE_AND_MASK("ich#", 48, 48, 1, true),
-    ICNS_48x48_4BIT_IMAGE("ich4", 48, 48, 4, false),
-    ICNS_48x48_8BIT_IMAGE("ich8", 48, 48, 8, false),
-    ICNS_48x48_32BIT_IMAGE("ih32", 48, 48, 32, false),
+    ICNS_64x64_32BIT_ARGB_IMAGE("icp6", 64, 64, 32, false, true), ICNS_64x64_32BIT_RETINA_IMAGE("ic12", 64, 64, 32, false, true),
 
-    ICNS_128x128_8BIT_MASK("t8mk", 128, 128, 8, true),
-    ICNS_128x128_32BIT_IMAGE("it32", 128, 128, 32, false),
+    ICNS_128x128_8BIT_MASK("t8mk", 128, 128, 8, true, false), ICNS_128x128_32BIT_IMAGE("it32", 128, 128, 32, false, false), ICNS_128x128_32BIT_ARGB_IMAGE("ic07", 128, 128, 32, false, true),
 
-    ICNS_256x256_32BIT_ARGB_IMAGE("ic08", 256, 256, 32, false),
+    ICNS_256x256_32BIT_ARGB_IMAGE("ic08", 256, 256, 32, false, true), ICNS_256x256_32BIT_RETINA_IMAGE("ic13", 256, 256, 32, false, true),
 
-    ICNS_512x512_32BIT_ARGB_IMAGE("ic09", 512, 512, 32, false);
+    ICNS_512x512_32BIT_ARGB_IMAGE("ic09", 512, 512, 32, false, true), ICNS_512x512_32BIT_RETINA_IMAGE("ic14", 512, 512, 32, false, true),
 
-    private static final IcnsType[] ALL_IMAGE_TYPES = {
-            ICNS_16x12_1BIT_IMAGE_AND_MASK,
-            ICNS_16x12_4BIT_IMAGE,
-            ICNS_16x12_8BIT_IMAGE,
-            ICNS_16x16_1BIT_IMAGE_AND_MASK,
-            ICNS_16x16_4BIT_IMAGE,
-            ICNS_16x16_8BIT_IMAGE,
-            ICNS_16x16_32BIT_IMAGE,
-            ICNS_32x32_1BIT_IMAGE_AND_MASK,
-            ICNS_32x32_4BIT_IMAGE,
-            ICNS_32x32_8BIT_IMAGE,
-            ICNS_32x32_32BIT_IMAGE,
-            ICNS_48x48_1BIT_IMAGE_AND_MASK,
-            ICNS_48x48_4BIT_IMAGE,
-            ICNS_48x48_8BIT_IMAGE,
-            ICNS_48x48_32BIT_IMAGE,
-            ICNS_128x128_32BIT_IMAGE,
-            ICNS_256x256_32BIT_ARGB_IMAGE,
-            ICNS_512x512_32BIT_ARGB_IMAGE};
+    ICNS_1024x1024_32BIT_ARGB_IMAGE("ic10", 1024, 1024, 32, false, true);
 
-    private static final IcnsType[] ALL_MASK_TYPES = {
-            ICNS_16x12_1BIT_IMAGE_AND_MASK,
-            ICNS_16x16_1BIT_IMAGE_AND_MASK,
-            ICNS_16x16_8BIT_MASK,
-            ICNS_32x32_1BIT_IMAGE_AND_MASK,
-            ICNS_32x32_8BIT_MASK,
-            ICNS_48x48_1BIT_IMAGE_AND_MASK,
-            ICNS_48x48_8BIT_MASK,
-            ICNS_128x128_8BIT_MASK};
+    private static final IcnsType[] ALL_IMAGE_TYPES = { ICNS_16x12_1BIT_IMAGE_AND_MASK, ICNS_16x12_4BIT_IMAGE, ICNS_16x12_8BIT_IMAGE, ICNS_16x16_1BIT_IMAGE_AND_MASK, ICNS_16x16_4BIT_IMAGE, ICNS_16x16_8BIT_IMAGE, ICNS_16x16_32BIT_IMAGE, ICNS_16x16_32BIT_ARGB_IMAGE, ICNS_32x32_1BIT_MONO_IMAGE, ICNS_32x32_1BIT_IMAGE_AND_MASK, ICNS_32x32_4BIT_IMAGE, ICNS_32x32_8BIT_IMAGE, ICNS_32x32_32BIT_IMAGE, ICNS_32x32_32BIT_ARGB_IMAGE, ICNS_32x32_32BIT_RETINA_IMAGE, ICNS_48x48_1BIT_IMAGE_AND_MASK, ICNS_48x48_4BIT_IMAGE, ICNS_48x48_8BIT_IMAGE, ICNS_48x48_32BIT_IMAGE, ICNS_64x64_32BIT_ARGB_IMAGE, ICNS_64x64_32BIT_RETINA_IMAGE, ICNS_128x128_32BIT_IMAGE, ICNS_128x128_32BIT_ARGB_IMAGE, ICNS_256x256_32BIT_ARGB_IMAGE, ICNS_256x256_32BIT_RETINA_IMAGE, ICNS_512x512_32BIT_ARGB_IMAGE, ICNS_512x512_32BIT_RETINA_IMAGE, ICNS_1024x1024_32BIT_ARGB_IMAGE };
+
+    private static final IcnsType[] ALL_MASK_TYPES = { ICNS_16x12_1BIT_IMAGE_AND_MASK, ICNS_16x16_1BIT_IMAGE_AND_MASK, ICNS_16x16_8BIT_MASK, ICNS_32x32_1BIT_IMAGE_AND_MASK, ICNS_32x32_8BIT_MASK, ICNS_48x48_1BIT_IMAGE_AND_MASK, ICNS_48x48_8BIT_MASK, ICNS_128x128_8BIT_MASK };
 
     private final int type;
+    private final String typeName;
     private final int width;
     private final int height;
     private final int bitsPerPixel;
     private final boolean hasMask;
+    private final boolean isPngOrJpeg2000;
 
-    private IcnsType(final String type, final int width, final int height, final int bitsPerPixel, final boolean hasMask) {
+    private IcnsType(final String type, final int width, final int height, final int bitsPerPixel, final boolean hasMask, final boolean isPngOrJpeg2000) {
         this.type = typeAsInt(type);
+        this.typeName = type;
         this.width = width;
         this.height = height;
         this.bitsPerPixel = bitsPerPixel;
         this.hasMask = hasMask;
+        this.isPngOrJpeg2000 = isPngOrJpeg2000;
     }
 
     public int getType() {
-        return type;
+        return this.type;
+    }
+
+    public String getTypeName() {
+        return this.typeName;
     }
 
     public int getWidth() {
-        return width;
+        return this.width;
     }
 
     public int getHeight() {
-        return height;
+        return this.height;
     }
 
     public int getBitsPerPixel() {
-        return bitsPerPixel;
+        return this.bitsPerPixel;
     }
 
     public boolean hasMask() {
-        return hasMask;
+        return this.hasMask;
+    }
+
+    public boolean isPngOrJpeg2000() {
+        return this.isPngOrJpeg2000;
     }
 
     @Override
     public String toString() {
-        return getClass().getName() + "[" + "width=" + width + "," + "height="
-                + height + "," + "bpp=" + bitsPerPixel + "," + "hasMask="
-                + hasMask + "]";
+        return getClass().getName()
+            + "["
+            + "width="
+            + this.width
+            + ","
+            + "height="
+            + this.height
+            + ","
+            + "bpp="
+            + this.bitsPerPixel
+            + ","
+            + "hasMask="
+            + this.hasMask
+            + "]";
     }
 
     public static IcnsType findAnyType(final int type) {
@@ -146,8 +130,8 @@ enum IcnsType {
     public static IcnsType find8BPPMaskType(final IcnsType imageType) {
         for (final IcnsType allMaskType : ALL_MASK_TYPES) {
             if (allMaskType.getBitsPerPixel() == 8
-                    && allMaskType.getWidth() == imageType.getWidth()
-                    && allMaskType.getHeight() == imageType.getHeight()) {
+                && allMaskType.getWidth() == imageType.getWidth()
+                && allMaskType.getHeight() == imageType.getHeight()) {
                 return allMaskType;
             }
         }
@@ -157,8 +141,8 @@ enum IcnsType {
     public static IcnsType find1BPPMaskType(final IcnsType imageType) {
         for (final IcnsType allMaskType : ALL_MASK_TYPES) {
             if (allMaskType.getBitsPerPixel() == 1
-                    && allMaskType.getWidth() == imageType.getWidth()
-                    && allMaskType.getHeight() == imageType.getHeight()) {
+                && allMaskType.getWidth() == imageType.getWidth()
+                && allMaskType.getHeight() == imageType.getHeight()) {
                 return allMaskType;
             }
         }
@@ -166,7 +150,7 @@ enum IcnsType {
     }
 
     public static int typeAsInt(final String type) {
-        byte[] bytes;
+        final byte[] bytes;
         try {
             bytes = type.getBytes("US-ASCII");
         } catch (final UnsupportedEncodingException unsupportedEncodingException) {
@@ -175,10 +159,10 @@ enum IcnsType {
         if (bytes.length != 4) {
             throw new IllegalArgumentException("Invalid ICNS type");
         }
-        return ((0xff & bytes[0]) << 24) 
-             | ((0xff & bytes[1]) << 16)
-             | ((0xff & bytes[2]) << 8)
-             | (0xff & bytes[3]);
+        return ((0xff & bytes[0]) << 24)
+            | ((0xff & bytes[1]) << 16)
+            | ((0xff & bytes[2]) << 8)
+            | (0xff & bytes[3]);
     }
 
     public static String describeType(final int type) {

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsGetAllBufferedImagesTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsGetAllBufferedImagesTest.java
@@ -1,0 +1,63 @@
+package org.apache.commons.imaging.formats.icns;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.imaging.ImageFormat;
+import org.apache.commons.imaging.ImageFormats;
+import org.apache.commons.imaging.Imaging;
+import org.junit.Test;
+
+/**
+ * Created by mw on 15.09.16.
+ */
+public class IcnsGetAllBufferedImagesTest {
+
+    private static final String ICNS_FILES = "src/test/data/images/icns/2/";
+    private static final String DIR_ICONS_CACHE = "src/test/data/images/icns/extractedICNS/";
+
+    @Test
+    public void testGetAllBufferedImages() {
+
+        if (!new File(DIR_ICONS_CACHE).exists()) {
+            new File(DIR_ICONS_CACHE).mkdir();
+        }
+
+        final ImageFormat format = ImageFormats.PNG;
+        final Map<String, Object> params = new HashMap<>();
+
+        final File icnsTestFiles = new File(ICNS_FILES);
+        final File[] files = icnsTestFiles.listFiles();
+        final IcnsImageParser icnsImageParser = new IcnsImageParser();
+        for (final File icns : files) {
+            try {
+                final List<Map<BufferedImage, IcnsType>> bufferedImages = icnsImageParser.getAllBufferedImagesWithType(icns);
+
+                int counter = 0;
+                for (final Map<BufferedImage, IcnsType> map : bufferedImages) {
+                    final Iterator<BufferedImage> iterator = map.keySet().iterator();
+                    while (iterator.hasNext()) {
+                        final BufferedImage image = iterator.next();
+                        final String name = icns.getName();
+                        final String type = map.get(image).getTypeName();
+                        final int width = image.getWidth();
+                        final int height = image.getHeight();
+                        final int pixelSize = image.getColorModel().getPixelSize();
+                        System.out.println(name + " -> [" + type + "]" + pixelSize + " | " + width + "x" + height);
+                        final File cachedImageFile = new File(DIR_ICONS_CACHE + name + "_[" + type + "]_" + width + "x" + height + "_" + pixelSize + "bit_" + counter + "." + format.getExtension());
+                        Imaging.writeImage(image, cachedImageFile, format, params);
+                        counter++;
+                    }
+                }
+                System.out.println("------------------- " + counter + " icons -------------------");
+            } catch (final Exception e) {
+                continue;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This update adds support for JPEG2000 icons via jai-imageio-jpeg2000. 
Also this adds support for extraction of larger images up to 1024px, normal and retina.

In need for this update, I enhanced this Library, and it works. 

So now I want to commit it to the community.

Maybe it is not beautiful, but it works fine and adds some important capabilities for ICNS extraction.