### PR TITLE
Imaging-209 PnmImageParser throws ImageWriteException when writing

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -364,6 +364,11 @@ public class PnmImageParser extends ImageParser {
         if (params.containsKey(PARAM_KEY_FORMAT)) {
             params.remove(PARAM_KEY_FORMAT);
         }
+
+        // clear rawbits key.
+        if (params.containsKey(PARAM_KEY_PNM_RAWBITS)) {
+            params.remove(PARAM_KEY_PNM_RAWBITS);
+        }
         
         if (!params.isEmpty()) {
             final Object firstKey = params.keySet().iterator().next();

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
@@ -16,17 +16,25 @@
  */
 package org.apache.commons.imaging.formats.pnm;
 
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageReadException;
+import org.apache.commons.imaging.ImageWriteException;
+import org.apache.commons.imaging.Imaging;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PnmImageParserTest {
 
@@ -42,6 +50,30 @@ public class PnmImageParserTest {
         assertEquals(results.getWidth(), 3);
         assertEquals(results.getHeight(), 2);
         assertEquals(results.getNumberOfImages(), 1);
+    }
+
+    @Test
+    public void testWriteImageRaw_happyCase() throws ImageWriteException,
+                                                     ImageReadException, IOException {
+        BufferedImage srcImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+        final Map<String, Object> params = new HashMap<>();
+        params.put(PnmImageParser.PARAM_KEY_PNM_RAWBITS, PnmImageParser.PARAM_VALUE_PNM_RAWBITS_YES);
+
+        final byte[] dstBytes = Imaging.writeImageToBytes(srcImage, ImageFormats.PNM, params);
+        final BufferedImage dstImage = Imaging.getBufferedImage(dstBytes);
+
+        assertTrue(srcImage.getWidth() == dstImage.getWidth());
+        assertTrue(srcImage.getHeight() == dstImage.getHeight());
+
+        DataBufferInt srcData = (DataBufferInt) srcImage.getRaster().getDataBuffer();
+        DataBufferInt dstData = (DataBufferInt) dstImage.getRaster().getDataBuffer();
+
+        for (int bank = 0; bank < srcData.getNumBanks(); bank++) {
+            int[] actual = srcData.getData(bank);
+            int[] expected = dstData.getData(bank);
+
+            assertArrayEquals(actual, expected);
+        }
     }
 
     /**


### PR DESCRIPTION
if PnmImageParser.PARAM_KEY_PNM_RAWBITS is provided.

I fixed the issue and added a test to cover it.

Issue can be found here: https://issues.apache.org/jira/browse/IMAGING-209