### PR TITLE
IMAGING-154 Removed Debug class

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,9 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
     <release version="1.0" date="TBA" description="First major release">
+      <action issue="IMAGING-154" dev="kinow" type="update">
+        Remove Debug class
+      </action>
       <action issue="IMAGING-124" dev="kinow" type="update" due-to="Jens Kapitza">
         Tidy up IconParser
       </action>

--- a/src/main/java/org/apache/commons/imaging/FormatCompliance.java
+++ b/src/main/java/org/apache/commons/imaging/FormatCompliance.java
@@ -16,18 +16,22 @@
  */
 package org.apache.commons.imaging;
 
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Provides information about the compliance of a specified data 
  * source (byte array, file, etc&#46;) to an image format.
  */
 public class FormatCompliance {
+
+    private final static Logger LOGGER = Logger.getLogger(FormatCompliance.class.getName());
+
     private final boolean failOnError;
     private final String description;
     private final List<String> comments = new ArrayList<>();
@@ -68,7 +72,14 @@ public class FormatCompliance {
     }
 
     public void dump() {
-        dump(new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset())));
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            dump(pw);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
     }
 
     public void dump(final PrintWriter pw) {

--- a/src/main/java/org/apache/commons/imaging/ImageDump.java
+++ b/src/main/java/org/apache/commons/imaging/ImageDump.java
@@ -20,6 +20,7 @@ import java.awt.color.ColorSpace;
 import java.awt.color.ICC_ColorSpace;
 import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.icc.IccProfileInfo;
 import org.apache.commons.imaging.icc.IccProfileParser;
@@ -29,6 +30,9 @@ import org.apache.commons.imaging.icc.IccProfileParser;
  * image files.
  */
 public class ImageDump {
+
+    private static final Logger LOGGER = Logger.getLogger(ImageDump.class.getName());
+
     private String colorSpaceTypeToName(final ColorSpace cs) {
         // System.out.println(prefix + ": " + "type: "
         // + cs.getType() );
@@ -54,11 +58,11 @@ public class ImageDump {
     }
 
     public void dumpColorSpace(final String prefix, final ColorSpace cs) {
-        System.out.println(prefix + ": " + "type: " + cs.getType() + " ("
+        LOGGER.fine(prefix + ": " + "type: " + cs.getType() + " ("
                 + colorSpaceTypeToName(cs) + ")");
 
         if (!(cs instanceof ICC_ColorSpace)) {
-            System.out.println(prefix + ": " + "Unknown ColorSpace: "
+            LOGGER.fine(prefix + ": " + "Unknown ColorSpace: "
                     + cs.getClass().getName());
             return;
         }
@@ -79,7 +83,7 @@ public class ImageDump {
     }
 
     public void dump(final String prefix, final BufferedImage src) {
-        System.out.println(prefix + ": " + "dump");
+        LOGGER.fine(prefix + ": " + "dump");
         dumpColorSpace(prefix, src.getColorModel().getColorSpace());
         dumpBIProps(prefix, src);
     }
@@ -87,11 +91,11 @@ public class ImageDump {
     public void dumpBIProps(final String prefix, final BufferedImage src) {
         final String[] keys = src.getPropertyNames();
         if (keys == null) {
-            System.out.println(prefix + ": no props");
+            LOGGER.fine(prefix + ": no props");
             return;
         }
         for (final String key : keys) {
-            System.out.println(prefix + ": " + key + ": "
+            LOGGER.fine(prefix + ": " + key + ": "
                     + src.getProperty(key));
         }
     }

--- a/src/main/java/org/apache/commons/imaging/ImageInfo.java
+++ b/src/main/java/org/apache/commons/imaging/ImageInfo.java
@@ -20,6 +20,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * ImageInfo represents a collection of basic properties of an image, such as
@@ -75,6 +76,8 @@ public class ImageInfo {
             return description;
         }
     }
+
+    private static final Logger LOGGER = Logger.getLogger(ImageInfo.class.getName());
 
     private final String formatDetails; // ie version
 
@@ -274,7 +277,7 @@ public class ImageInfo {
     }
 
     public void dump() {
-        System.out.print(toString());
+        LOGGER.fine(toString());
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.common.BinaryFileParser;
 import org.apache.commons.imaging.common.BufferedImageFactory;
@@ -96,6 +98,8 @@ import org.apache.commons.imaging.formats.xpm.XpmImageParser;
  * from ImageParser are encouraged to include such checks in their code.
  */
 public abstract class ImageParser extends BinaryFileParser {
+
+    private static final Logger LOGGER = Logger.getLogger(ImageParser.class.getName());
 
     /**
      * Gets an array of new instances of all image parsers.
@@ -266,9 +270,8 @@ public abstract class ImageParser extends BinaryFileParser {
      */
     public final ImageMetadata getMetadata(final File file, final Map<String, Object> params)
             throws ImageReadException, IOException {
-        if (getDebug()) {
-            System.out.println(getName() + ".getMetadata" + ": "
-                    + file.getName());
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(getName() + ".getMetadata" + ": " + file.getName());
         }
 
         if (!canAcceptExtension(file)) {
@@ -756,8 +759,8 @@ public abstract class ImageParser extends BinaryFileParser {
             return null;
         }
 
-        if (getDebug()) {
-            System.out.println(getName() + ": " + file.getName());
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(getName() + ": " + file.getName());
         }
 
         return getICCProfileBytes(new ByteSourceFile(file), params);
@@ -812,8 +815,8 @@ public abstract class ImageParser extends BinaryFileParser {
             return null;
         }
 
-        if (getDebug()) {
-            System.out.println(getName() + ": " + file.getName());
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(getName() + ": " + file.getName());
         }
 
         return dumpImageFile(new ByteSourceFile(file));

--- a/src/main/java/org/apache/commons/imaging/ImagingConstants.java
+++ b/src/main/java/org/apache/commons/imaging/ImagingConstants.java
@@ -26,13 +26,6 @@ package org.apache.commons.imaging;
 public final class ImagingConstants {
     
     /**
-     * Parameter key. Applies to read and write operations.
-     * <p>
-     * Valid values: Boolean.TRUE and Boolean.FALSE.
-     */
-    public static final String PARAM_KEY_VERBOSE = "VERBOSE";
-
-    /**
      * Parameter key. Used to hint the filename when reading from a byte array
      * or InputStream. The filename hint can help disambiguate what file the
      * image format.

--- a/src/main/java/org/apache/commons/imaging/common/BinaryFileParser.java
+++ b/src/main/java/org/apache/commons/imaging/common/BinaryFileParser.java
@@ -16,15 +16,19 @@
  */
 package org.apache.commons.imaging.common;
 
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class BinaryFileParser {
+
+    private static final Logger LOGGER = Logger.getLogger(BinaryFileParser.class.getName());
+
     // default byte order for Java, many file formats.
     private ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
-    private boolean debug;
 
     public BinaryFileParser(final ByteOrder byteOrder) {
         this.byteOrder = byteOrder;
@@ -45,18 +49,15 @@ public class BinaryFileParser {
         return byteOrder;
     }
 
-    public boolean getDebug() {
-        return debug;
-    }
-
-    public void setDebug(final boolean debug) {
-        this.debug = debug;
-    }
-
     protected final void debugNumber(final String msg, final int data, final int bytes) {
-        final PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-        debugNumber(pw, msg, data, bytes);
-        pw.flush();
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            debugNumber(pw, msg, data, bytes);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
     }
 
     protected final void debugNumber(final PrintWriter pw, final String msg, final int data, final int bytes) {

--- a/src/main/java/org/apache/commons/imaging/common/BinaryFunctions.java
+++ b/src/main/java/org/apache/commons/imaging/common/BinaryFunctions.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 
@@ -30,6 +31,9 @@ import org.apache.commons.imaging.ImageReadException;
  * Convenience methods for various binary and I/O operations.
  */
 public final class BinaryFunctions {
+
+    private static final Logger LOGGER = Logger.getLogger(BinaryFunctions.class.getName());
+
     private BinaryFunctions() {
     }
     
@@ -245,7 +249,7 @@ public final class BinaryFunctions {
     }
 
     public static void printCharQuad(final String msg, final int i) {
-        System.out.println(msg + ": '" + (char) (0xff & (i >> 24))
+        LOGGER.finest(msg + ": '" + (char) (0xff & (i >> 24))
                 + (char) (0xff & (i >> 16)) + (char) (0xff & (i >> 8))
                 + (char) (0xff & (i >> 0)) + "'");
 
@@ -259,7 +263,7 @@ public final class BinaryFunctions {
     }
 
     public static void printByteBits(final String msg, final byte i) {
-        System.out.println(msg + ": '" + Integer.toBinaryString(0xff & i));
+        LOGGER.finest(msg + ": '" + Integer.toBinaryString(0xff & i));
     }
 
     public static int charsToQuad(final char c1, final char c2, final char c3, final char c4) {

--- a/src/main/java/org/apache/commons/imaging/formats/bmp/PixelParserRle.java
+++ b/src/main/java/org/apache/commons/imaging/formats/bmp/PixelParserRle.java
@@ -17,12 +17,15 @@
 package org.apache.commons.imaging.formats.bmp;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.BinaryFunctions;
 import org.apache.commons.imaging.common.ImageBuilder;
 
 class PixelParserRle extends PixelParser {
+
+    private static final Logger LOGGER = Logger.getLogger(PixelParserRle.class.getName());
 
     public PixelParserRle(final BmpHeaderInfo bhi, final byte[] colorTable, final byte[] imageData) {
         super(bhi, colorTable, imageData);
@@ -75,7 +78,7 @@ class PixelParserRle extends PixelParser {
                 imageBuilder.setRGB(x, y, rgb);
                 // bi.setRGB(x, y, 0xff00ff00);
             } else {
-                System.out.println("skipping bad pixel (" + x + "," + y + ")");
+                LOGGER.fine("skipping bad pixel (" + x + "," + y + ")");
             }
 
             x++;

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -47,7 +47,7 @@ import org.apache.commons.imaging.formats.pcx.PcxConstants;
 import org.apache.commons.imaging.formats.pcx.PcxImageParser;
 
 public class DcxImageParser extends ImageParser {
-    // See http://www.fileformat.info/format/pcx/egff.htm for documentation
+    // See http://www.fileformat.fine/format/pcx/egff.htm for documentation
     private static final String DEFAULT_EXTENSION = ".dcx";
     private static final String[] ACCEPTED_EXTENSIONS = { ".dcx", };
 

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
@@ -17,7 +17,6 @@
 package org.apache.commons.imaging.formats.icns;
 
 import static org.apache.commons.imaging.ImagingConstants.PARAM_KEY_FORMAT;
-import static org.apache.commons.imaging.ImagingConstants.PARAM_KEY_VERBOSE;
 import static org.apache.commons.imaging.common.BinaryFunctions.read4Bytes;
 import static org.apache.commons.imaging.common.BinaryFunctions.readBytes;
 
@@ -85,10 +84,6 @@ public class IcnsImageParser extends ImageParser {
         // make copy of params; we'll clear keys as we consume them.
         params = params == null ? new HashMap<String, Object>() : new HashMap<>(params);
 
-        if (params.containsKey(PARAM_KEY_VERBOSE)) {
-            params.remove(PARAM_KEY_VERBOSE);
-        }
-
         if (!params.isEmpty()) {
             final Object firstKey = params.keySet().iterator().next();
             throw new ImageReadException("Unknown parameter: " + firstKey);
@@ -113,10 +108,6 @@ public class IcnsImageParser extends ImageParser {
             throws ImageReadException, IOException {
         // make copy of params; we'll clear keys as we consume them.
         params = (params == null) ? new HashMap<String, Object>() : new HashMap<>(params);
-
-        if (params.containsKey(PARAM_KEY_VERBOSE)) {
-            params.remove(PARAM_KEY_VERBOSE);
-        }
 
         if (!params.isEmpty()) {
             final Object firstKey = params.keySet().iterator().next();

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageMetadata.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageMetadata.java
@@ -34,7 +34,7 @@ import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageData;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class JpegImageMetadata implements ImageMetadata {
     private final JpegPhotoshopMetadata photoshop;

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageFormat;
 import org.apache.commons.imaging.ImageFormats;
@@ -55,12 +57,15 @@ import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffImageParser;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 import static org.apache.commons.imaging.ImagingConstants.*;
 import static org.apache.commons.imaging.common.BinaryFunctions.*;
 
 public class JpegImageParser extends ImageParser {
+
+    private static final Logger LOGGER = Logger.getLogger(JpegImageParser.class.getName());
+
     private static final String DEFAULT_EXTENSION = ".jpg";
     private static final String[] ACCEPTED_EXTENSIONS = { ".jpg", ".jpeg", };
     
@@ -298,12 +303,8 @@ public class JpegImageParser extends ImageParser {
 
         final byte[] bytes = assembleSegments(filtered);
 
-        if (getDebug()) {
-            System.out.println("bytes" + ": " + bytes.length);
-        }
-
-        if (getDebug()) {
-            System.out.println("");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("bytes" + ": " + bytes.length);
         }
 
         return bytes;
@@ -369,9 +370,8 @@ public class JpegImageParser extends ImageParser {
         }
 
         final List<Segment> exifSegments = filterAPP1Segments(segments);
-        if (getDebug()) {
-            System.out.println("exif_segments.size" + ": "
-                    + exifSegments.size());
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("exif_segments.size" + ": " + exifSegments.size());
         }
 
         // Debug.debug("segments", segments);

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegPhotoshopMetadata.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegPhotoshopMetadata.java
@@ -23,7 +23,7 @@ import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.iptc.IptcRecord;
 import org.apache.commons.imaging.formats.jpeg.iptc.IptcTypes;
 import org.apache.commons.imaging.formats.jpeg.iptc.PhotoshopApp13Data;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class JpegPhotoshopMetadata extends GenericImageMetadata {
 

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegUtils.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegUtils.java
@@ -29,7 +29,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.BinaryFileParser;
 import org.apache.commons.imaging.common.ByteConversions;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class JpegUtils extends BinaryFileParser {
     public JpegUtils() {

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/decoder/Dct.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/decoder/Dct.java
@@ -252,7 +252,7 @@ final class Dct {
 
     /**
      * Fast inverse Dct using AA&N. This is taken from the beautiful
-     * http://vsr.informatik.tu-chemnitz.de/~jan/MPEG/HTML/IDCT.html which gives
+     * http://vsr.finermatik.tu-chemnitz.de/~jan/MPEG/HTML/IDCT.html which gives
      * easy equations and properly explains constants and scaling factors. Terms
      * have been inlined and the negation optimized out of existence.
      */

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegment.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegment.java
@@ -73,10 +73,6 @@ public class JfifSegment extends Segment {
                     "Not a Valid JPEG File: missing thumbnail");
 
         }
-
-        if (getDebug()) {
-            System.out.println("");
-        }
     }
 
 }

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SofnSegment.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SofnSegment.java
@@ -19,12 +19,17 @@ package org.apache.commons.imaging.formats.jpeg.segments;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.formats.jpeg.JpegConstants;
 
 import static org.apache.commons.imaging.common.BinaryFunctions.*;
 
 public class SofnSegment extends Segment {
+
+    private static final Logger LOGGER = Logger.getLogger(SofnSegment.class.getName());
+
     public final int width;
     public final int height;
     public final int numberOfComponents;
@@ -54,8 +59,8 @@ public class SofnSegment extends Segment {
             throws IOException {
         super(marker, markerLength);
 
-        if (getDebug()) {
-            System.out.println("SOF0Segment marker_length: " + markerLength);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("SOF0Segment marker_length: " + markerLength);
         }
 
         precision = readByte("Data_precision", is, "Not a Valid JPEG File");
@@ -77,10 +82,6 @@ public class SofnSegment extends Segment {
             components[i] = new Component(componentIdentifier,
                     horizontalSamplingFactor, verticalSamplingFactor,
                     quantTabDestSelector);
-        }
-
-        if (getDebug()) {
-            System.out.println("");
         }
     }
     

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegment.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegment.java
@@ -19,10 +19,15 @@ package org.apache.commons.imaging.formats.jpeg.segments;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.apache.commons.imaging.common.BinaryFunctions.*;
 
 public class SosSegment extends Segment {
+
+    private static final Logger LOGGER = Logger.getLogger(SosSegment.class.getName());
+
     public final int numberOfComponents;
     private final Component[] components;
     public final int startOfSpectralSelection;
@@ -50,8 +55,8 @@ public class SosSegment extends Segment {
     public SosSegment(final int marker, final int markerLength, final InputStream is) throws IOException {
         super(marker, markerLength);
 
-        if (getDebug()) {
-            System.out.println("SosSegment marker_length: " + markerLength);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("SosSegment marker_length: " + markerLength);
         }
 
         // Debug.debug("SOS", marker_length);
@@ -91,10 +96,6 @@ public class SosSegment extends Segment {
         // successive_approximation_bit_position);
         successiveApproximationBitHigh = (successiveApproximationBitPosition >> 4) & 0xf;
         successiveApproximationBitLow = successiveApproximationBitPosition & 0xf;
-
-        if (getDebug()) {
-            System.out.println("");
-        }
     }
     
     /**

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -54,8 +54,8 @@ import org.apache.commons.imaging.common.bytesource.ByteSource;
 
 public class PcxImageParser extends ImageParser {
     // ZSoft's official spec is at http://www.qzx.com/pc-gpe/pcx.txt
-    // (among other places) but it's pretty thin. The fileformat.info document
-    // at http://www.fileformat.info/format/pcx/egff.htm is a little better
+    // (among other places) but it's pretty thin. The fileformat.fine document
+    // at http://www.fileformat.fine/format/pcx/egff.htm is a little better
     // but their gray sample image seems corrupt. PCX files themselves are
     // the ultimate test but pretty hard to find nowdays, so the best
     // test is against other image viewers (Irfanview is pretty good).

--- a/src/main/java/org/apache/commons/imaging/formats/png/GammaCorrection.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/GammaCorrection.java
@@ -16,23 +16,27 @@
  */
 package org.apache.commons.imaging.formats.png;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class GammaCorrection {
-    private static final boolean DEBUG = false;
+
+    private static final Logger LOGGER = Logger.getLogger(GammaCorrection.class.getName());
 
     private final int[] lookupTable;
 
     public GammaCorrection(final double srcGamma, final double dstGamma) {
 
-        if (DEBUG) {
-            System.out.println("src_gamma: " + srcGamma);
-            System.out.println("dst_gamma: " + dstGamma);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("src_gamma: " + srcGamma);
+            LOGGER.finest("dst_gamma: " + dstGamma);
         }
 
         lookupTable = new int[256];
         for (int i = 0; i < 256; i++) {
             lookupTable[i] = correctSample(i, srcGamma, dstGamma);
-            if (DEBUG) {
-                System.out.println("lookup_table[" + i + "]: " + lookupTable[i]);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest("lookup_table[" + i + "]: " + lookupTable[i]);
             }
         }
     }

--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.imaging.formats.png;
 
-import static org.apache.commons.imaging.ImagingConstants.PARAM_KEY_VERBOSE;
 import static org.apache.commons.imaging.common.BinaryFunctions.printCharQuad;
 import static org.apache.commons.imaging.common.BinaryFunctions.read4Bytes;
 import static org.apache.commons.imaging.common.BinaryFunctions.readAndVerifyBytes;
@@ -39,6 +38,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.InflaterInputStream;
 
 import org.apache.commons.imaging.ColorTools;
@@ -70,6 +71,9 @@ import org.apache.commons.imaging.formats.png.transparencyfilters.TransparencyFi
 import org.apache.commons.imaging.icc.IccProfileParser;
 
 public class PngImageParser extends ImageParser {
+
+    private static final Logger LOGGER = Logger.getLogger(PngImageParser.class.getName());
+
     private static final String DEFAULT_EXTENSION = ".png";
     private static final String[] ACCEPTED_EXTENSIONS = { DEFAULT_EXTENSION, };
 
@@ -146,14 +150,10 @@ public class PngImageParser extends ImageParser {
         final List<PngChunk> result = new ArrayList<>();
 
         while (true) {
-            if (getDebug()) {
-                System.out.println("");
-            }
-
             final int length = read4Bytes("Length", is, "Not a Valid PNG File", getByteOrder());
             final int chunkType = read4Bytes("ChunkType", is, "Not a Valid PNG File", getByteOrder());
 
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ChunkType", chunkType);
                 debugNumber("Length", length, 4);
             }
@@ -167,7 +167,7 @@ public class PngImageParser extends ImageParser {
                 skipBytes(is, length, "Not a Valid PNG File");
             }
 
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 if (bytes != null) {
                     debugNumber("bytes", bytes.length, 4);
                 }
@@ -482,10 +482,6 @@ public class PngImageParser extends ImageParser {
             throws ImageReadException, IOException {
         params = (params == null) ? new HashMap<String, Object>() : new HashMap<>(params);
 
-        if (params.containsKey(PARAM_KEY_VERBOSE)) {
-            params.remove(PARAM_KEY_VERBOSE);
-        }
-
         // if (params.size() > 0) {
         // Object firstKey = params.keySet().iterator().next();
         // throw new ImageWriteException("Unknown parameter: " + firstKey);
@@ -567,12 +563,12 @@ public class PngImageParser extends ImageParser {
 
             if (sRGBs.size() == 1) {
                 // no color management neccesary.
-                if (getDebug()) {
-                    System.out.println("sRGB, no color management neccesary.");
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest("sRGB, no color management neccesary.");
                 }
             } else if (iCCPs.size() == 1) {
-                if (getDebug()) {
-                    System.out.println("iCCP.");
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest("iCCP.");
                 }
 
                 final PngChunkIccp pngChunkiCCP = (PngChunkIccp) iCCPs.get(0);
@@ -674,8 +670,8 @@ public class PngImageParser extends ImageParser {
         final List<PngChunk> chunks = readChunks(byteSource, null, false);
         final List<PngChunk> IHDRs = filterChunks(chunks, ChunkType.IHDR);
         if (IHDRs.size() != 1) {
-            if (getDebug()) {
-                System.out.println("PNG contains more than one Header");
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest("PNG contains more than one Header");
             }
             return false;
         }
@@ -703,7 +699,7 @@ public class PngImageParser extends ImageParser {
     @Override
     public void writeImage(final BufferedImage src, final OutputStream os, final Map<String, Object> params)
             throws ImageWriteException, IOException {
-        new PngWriter(params).writeImage(src, os, params);
+        new PngWriter().writeImage(src, os, params);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/formats/png/PngWriter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngWriter.java
@@ -29,21 +29,12 @@ import java.util.zip.DeflaterOutputStream;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.PixelDensity;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.imaging.palette.Palette;
 import org.apache.commons.imaging.palette.PaletteFactory;
 import org.apache.commons.imaging.palette.SimplePalette;
-import org.apache.commons.imaging.util.Debug;
 
 class PngWriter {
-    private final boolean verbose;
-
-    public PngWriter(final boolean verbose) {
-        this.verbose = verbose;
-    }
-
-    public PngWriter(final Map<String, Object> params) {
-        this.verbose =  params != null && Boolean.TRUE.equals(params.get(ImagingConstants.PARAM_KEY_VERBOSE));
-    }
 
     /*
      1. IHDR: image header, which is the first chunk in a PNG datastream.
@@ -386,10 +377,6 @@ class PngWriter {
         if (params.containsKey(ImagingConstants.PARAM_KEY_FORMAT)) {
             params.remove(ImagingConstants.PARAM_KEY_FORMAT);
         }
-        // clear verbose key.
-        if (params.containsKey(ImagingConstants.PARAM_KEY_VERBOSE)) {
-            params.remove(ImagingConstants.PARAM_KEY_VERBOSE);
-        }
 
         final Map<String, Object> rawParams = new HashMap<>(params);
         if (params.containsKey(PngConstants.PARAM_KEY_PNG_FORCE_TRUE_COLOR)) {
@@ -419,15 +406,11 @@ class PngWriter {
         final int height = src.getHeight();
 
         final boolean hasAlpha = new PaletteFactory().hasTransparency(src);
-        if (verbose) {
-            Debug.debug("hasAlpha: " + hasAlpha);
-        }
+        Debug.debug("hasAlpha: " + hasAlpha);
         // int transparency = new PaletteFactory().getTransparency(src);
 
         boolean isGrayscale = new PaletteFactory().isGrayscale(src);
-        if (verbose) {
-            Debug.debug("isGrayscale: " + isGrayscale);
-        }
+        Debug.debug("isGrayscale: " + isGrayscale);
 
         PngColorType pngColorType;
         {
@@ -445,15 +428,11 @@ class PngWriter {
             } else {
                 pngColorType = PngColorType.getColorType(hasAlpha, isGrayscale);
             }
-            if (verbose) {
-                Debug.debug("colorType: " + pngColorType);
-            }
+            Debug.debug("colorType: " + pngColorType);
         }
 
         final byte bitDepth = getBitDepth(pngColorType, params);
-        if (verbose) {
-            Debug.debug("bitDepth: " + bitDepth);
-        }
+        Debug.debug("bitDepth: " + bitDepth);
 
         int sampleDepth;
         if (pngColorType == PngColorType.INDEXED_COLOR) {
@@ -461,9 +440,7 @@ class PngWriter {
         } else {
             sampleDepth = bitDepth;
         }
-        if (verbose) {
-            Debug.debug("sampleDepth: " + sampleDepth);
-        }
+        Debug.debug("sampleDepth: " + sampleDepth);
 
         {
             PngConstants.PNG_SIGNATURE.writeTo(os);

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
@@ -19,6 +19,8 @@ package org.apache.commons.imaging.formats.png.chunks;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.InflaterInputStream;
 
 import org.apache.commons.imaging.ImageReadException;
@@ -26,6 +28,9 @@ import org.apache.commons.imaging.ImageReadException;
 import static org.apache.commons.imaging.common.BinaryFunctions.*;
 
 public class PngChunkIccp extends PngChunk {
+
+    private static final Logger LOGGER = Logger.getLogger(PngChunkIccp.class.getName());
+
     // private final PngImageParser parser;
     public final String profileName;
     public final int compressionMethod;
@@ -57,18 +62,18 @@ public class PngChunkIccp extends PngChunk {
         compressedProfile = new byte[compressedProfileLength];
         System.arraycopy(bytes, index + 1 + 1, compressedProfile, 0, compressedProfileLength);
 
-        if (getDebug()) {
-            System.out.println("ProfileName: " + profileName);
-            System.out.println("ProfileName.length(): " + profileName.length());
-            System.out.println("CompressionMethod: " + compressionMethod);
-            System.out.println("CompressedProfileLength: " + compressedProfileLength);
-            System.out.println("bytes.length: " + bytes.length);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("ProfileName: " + profileName);
+            LOGGER.finest("ProfileName.length(): " + profileName.length());
+            LOGGER.finest("CompressionMethod: " + compressionMethod);
+            LOGGER.finest("CompressedProfileLength: " + compressedProfileLength);
+            LOGGER.finest("bytes.length: " + bytes.length);
         }
 
         uncompressedProfile = getStreamBytes(new InflaterInputStream(new ByteArrayInputStream(compressedProfile)));
 
-        if (getDebug()) {
-            System.out.println("UncompressedProfile: " + Integer.toString(bytes.length));
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("UncompressedProfile: " + Integer.toString(bytes.length));
         }
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkText.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkText.java
@@ -18,6 +18,8 @@ package org.apache.commons.imaging.formats.png.chunks;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.formats.png.PngText;
@@ -25,6 +27,9 @@ import org.apache.commons.imaging.formats.png.PngText;
 import static org.apache.commons.imaging.common.BinaryFunctions.*;
 
 public class PngChunkText extends PngTextChunk {
+
+    private static final Logger LOGGER = Logger.getLogger(PngChunkText.class.getName());
+
     public final String keyword;
     public final String text;
 
@@ -42,9 +47,9 @@ public class PngChunkText extends PngTextChunk {
         final int textLength = bytes.length - (index + 1);
         text = new String(bytes, index + 1, textLength, StandardCharsets.ISO_8859_1);
 
-        if (getDebug()) {
-            System.out.println("Keyword: " + keyword);
-            System.out.println("Text: " + text);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("Keyword: " + keyword);
+            LOGGER.finest("Text: " + text);
         }
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/psd/ImageResourceBlock.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/ImageResourceBlock.java
@@ -18,7 +18,7 @@ package org.apache.commons.imaging.formats.psd;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 class ImageResourceBlock {
     final int id;

--- a/src/main/java/org/apache/commons/imaging/formats/psd/PsdHeaderInfo.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/PsdHeaderInfo.java
@@ -16,11 +16,16 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.io.StringWriter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PsdHeaderInfo {
+
+    private static final Logger LOGGER = Logger.getLogger(PsdHeaderInfo.class.getName());
+
     public final int version;
     private final byte[] reserved;
     public final int channels;
@@ -45,9 +50,14 @@ public class PsdHeaderInfo {
     }
 
     public void dump() {
-        final PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-        dump(pw);
-        pw.flush();
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            dump(pw);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
     }
 
     public void dump(final PrintWriter pw) {
@@ -62,7 +72,6 @@ public class PsdHeaderInfo {
         pw.println("Reserved: " + reserved.length);
         pw.println("");
         pw.flush();
-
     }
 
 }

--- a/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageContents.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageContents.java
@@ -16,11 +16,16 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.io.StringWriter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PsdImageContents {
+
+    private static final Logger LOGGER = Logger.getLogger(PsdImageContents.class.getName());
+
     public final PsdHeaderInfo header;
 
     public final int ColorModeDataLength;
@@ -40,9 +45,14 @@ public class PsdImageContents {
     }
 
     public void dump() {
-        final PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-        dump(pw);
-        pw.flush();
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            dump(pw);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
     }
 
     public void dump(final PrintWriter pw) {

--- a/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/CompressedDataReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/CompressedDataReader.java
@@ -55,7 +55,6 @@ public class CompressedDataReader implements DataReader {
             scanlineBytecounts[i] = BinaryFunctions.read2Bytes("scanline_bytecount[" + i
                     + "]", is, "PSD: bad Image Data", bfp.getByteOrder());
         }
-        bfp.setDebug(false);
         // System.out.println("fImageContents.Compression: "
         // + imageContents.Compression);
 

--- a/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/UncompressedDataReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/UncompressedDataReader.java
@@ -45,8 +45,6 @@ public class UncompressedDataReader implements DataReader {
         final int width = header.columns;
         final int height = header.rows;
 
-        bfp.setDebug(false);
-
         final int channelCount = dataParser.getBasicChannelsCount();
         final int depth = header.depth;
         final MyBitInputStream mbis = new MyBitInputStream(is, ByteOrder.BIG_ENDIAN);

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/JpegImageData.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/JpegImageData.java
@@ -23,7 +23,7 @@ public class JpegImageData extends TiffElement.DataElement {
     }
 
     @Override
-    public String getElementDescription(final boolean verbose) {
+    public String getElementDescription() {
         return "Jpeg image data: " + getDataLength() + " bytes";
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffContents.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffContents.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class TiffContents {
     public final TiffHeader header;
@@ -71,7 +71,7 @@ public class TiffContents {
         return null;
     }
 
-    public void dissect(final boolean verbose) throws ImageReadException {
+    public void dissect() throws ImageReadException {
         final List<TiffElement> elements = getElements();
 
         Collections.sort(elements, TiffElement.COMPARATOR);
@@ -88,12 +88,10 @@ public class TiffContents {
             Debug.debug("element, start: " + element.offset + ", length: "
                     + element.length + ", end: "
                     + (element.offset + element.length) + ": "
-                    + element.getElementDescription(false));
-            if (verbose) {
-                final String verbosity = element.getElementDescription(true);
-                if (null != verbosity) {
-                    Debug.debug(verbosity);
-                }
+                    + element.getElementDescription());
+            final String verbosity = element.getElementDescription();
+            if (null != verbosity) {
+                Debug.debug(verbosity);
             }
 
             lastEnd = element.offset + element.length;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffDirectory.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffDirectory.java
@@ -79,11 +79,7 @@ public class TiffDirectory extends TiffElement {
     }
 
     @Override
-    public String getElementDescription(final boolean verbose) {
-        if (!verbose) {
-            return "TIFF Directory (" + description() + ")";
-        }
-
+    public String getElementDescription() {
         long entryOffset = offset + TiffConstants.TIFF_DIRECTORY_HEADER_LENGTH;
 
         final StringBuilder result = new StringBuilder();
@@ -708,10 +704,7 @@ public class TiffDirectory extends TiffElement {
         }
 
         @Override
-        public String getElementDescription(final boolean verbose) {
-            if (verbose) {
-                return null;
-            }
+        public String getElementDescription() {
             return "ImageDataElement";
         }
     }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffElement.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffElement.java
@@ -39,11 +39,7 @@ public abstract class TiffElement {
         this.length = length;
     }
 
-    public String getElementDescription() {
-        return getElementDescription(false);
-    }
-
-    public abstract String getElementDescription(boolean verbose);
+    public abstract String getElementDescription();
 
     public static abstract class DataElement extends TiffElement {
         private final byte[] data;
@@ -69,7 +65,7 @@ public abstract class TiffElement {
         }
 
         @Override
-        public String getElementDescription(final boolean verbose) {
+        public String getElementDescription() {
             return "Element, offset: " + offset + ", length: " + length
                     + ", last: " + (offset + length);
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffField.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffField.java
@@ -16,14 +16,16 @@
  */
 package org.apache.commons.imaging.formats.tiff;
 
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.BinaryFunctions;
@@ -36,6 +38,9 @@ import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
  * A TIFF field in a TIFF directory. Immutable.
  */
 public class TiffField {
+
+    private static final Logger LOGGER = Logger.getLogger(TiffField.class.getName());
+
     private final TagInfo tagInfo;
     private final int tag;
     private final int directoryType;
@@ -145,11 +150,7 @@ public class TiffField {
         }
 
         @Override
-        public String getElementDescription(final boolean verbose) {
-            if (verbose) {
-                return null;
-            }
-
+        public String getElementDescription() {
             return "OversizeValueElement, tag: " + getTagInfo().name
                     + ", fieldType: " + getFieldType().getName();
         }
@@ -355,9 +356,14 @@ public class TiffField {
     }
 
     public void dump() {
-        final PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-        dump(pw);
-        pw.flush();
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            dump(pw);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
     }
 
     public void dump(final PrintWriter pw) {

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffHeader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffHeader.java
@@ -34,11 +34,7 @@ public class TiffHeader extends TiffElement {
     }
 
     @Override
-    public String getElementDescription(final boolean verbose) {
-        if (verbose) {
-            return null;
-        }
-
+    public String getElementDescription() {
         return "TIFF Header";
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageData.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageData.java
@@ -147,7 +147,7 @@ public abstract class TiffImageData {
         }
 
         @Override
-        public String getElementDescription(final boolean verbose) {
+        public String getElementDescription() {
             return "Tiff image data: " + getDataLength() + " bytes";
         }
 
@@ -162,7 +162,7 @@ public abstract class TiffImageData {
         }
 
         @Override
-        public String getElementDescription(final boolean verbose) {
+        public String getElementDescription() {
             return "Tiff image data: " + getDataLength() + " bytes";
         }
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffReader.java
@@ -89,10 +89,6 @@ public class TiffReader extends BinaryFileParser {
 
         skipBytes(is, offsetToFirstIFD - 8, "Not a Valid TIFF File: couldn't find IFDs");
 
-        if (getDebug()) {
-            System.out.println("");
-        }
-
         return new TiffHeader(byteOrder, tiffVersion, offsetToFirstIFD);
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoGpsText.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoGpsText.java
@@ -26,7 +26,7 @@ import org.apache.commons.imaging.common.BinaryFunctions;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
 import org.apache.commons.imaging.formats.tiff.fieldtypes.FieldType;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 /**
  * Used by some GPS tags and the EXIF user comment tag,

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSet.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSet.java
@@ -25,7 +25,7 @@ import org.apache.commons.imaging.common.RationalNumber;
 import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryConstants;
 import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.*;
 

--- a/src/main/java/org/apache/commons/imaging/icc/IccProfileInfo.java
+++ b/src/main/java/org/apache/commons/imaging/icc/IccProfileInfo.java
@@ -19,10 +19,13 @@ package org.apache.commons.imaging.icc;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 
 public class IccProfileInfo {
+
+    private static final Logger LOGGER = Logger.getLogger(IccProfileInfo.class.getName());
 
     private final byte[] data;
     public final int profileSize;
@@ -92,7 +95,7 @@ public class IccProfileInfo {
     }
 
     public void dump(final String prefix) {
-        System.out.print(toString());
+        LOGGER.fine(toString());
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/icc/IccProfileParser.java
+++ b/src/main/java/org/apache/commons/imaging/icc/IccProfileParser.java
@@ -25,14 +25,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.common.BinaryFileParser;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
-import org.apache.commons.imaging.util.Debug;
 
 public class IccProfileParser extends BinaryFileParser {
+
+    private static final Logger LOGGER = Logger.getLogger(IccProfileParser.class.getName());
+
     public IccProfileParser() {
         this.setByteOrder(ByteOrder.BIG_ENDIAN);
     }
@@ -88,20 +92,16 @@ public class IccProfileParser extends BinaryFileParser {
             return result;
         } catch (final Exception e) {
             // Debug.debug("Error: " + file.getAbsolutePath());
-            Debug.debug(e);
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
         } finally {
             try {
                 if (is != null) {
                     is.close();
                 }
             } catch (final Exception e) {
-                Debug.debug(e);
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
 
-        }
-
-        if (getDebug()) {
-            Debug.debug();
         }
 
         return null;
@@ -111,13 +111,9 @@ public class IccProfileParser extends BinaryFileParser {
         final CachingInputStream cis = new CachingInputStream(is);
         is = cis;
 
-        if (getDebug()) {
-            Debug.debug();
-        }
-
         // setDebug(true);
 
-        // if (getDebug())
+        // if (LOGGER.isLoggable(Level.FINEST))
         // Debug.debug("length: " + length);
 
         try {
@@ -135,7 +131,7 @@ public class IccProfileParser extends BinaryFileParser {
             // }
 
             final int cmmTypeSignature = read4Bytes("Signature", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("CMMTypeSignature", cmmTypeSignature);
             }
 
@@ -143,58 +139,58 @@ public class IccProfileParser extends BinaryFileParser {
 
             final int profileDeviceClassSignature = read4Bytes("ProfileDeviceClassSignature", is, 
                     "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ProfileDeviceClassSignature", profileDeviceClassSignature);
             }
 
             final int colorSpace = read4Bytes("ColorSpace", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ColorSpace", colorSpace);
             }
 
             final int profileConnectionSpace = read4Bytes("ProfileConnectionSpace", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ProfileConnectionSpace", profileConnectionSpace);
             }
 
             skipBytes(is, 12, "Not a Valid ICC Profile");
 
             final int profileFileSignature = read4Bytes("ProfileFileSignature", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ProfileFileSignature", profileFileSignature);
             }
 
             final int primaryPlatformSignature = read4Bytes("PrimaryPlatformSignature", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("PrimaryPlatformSignature", primaryPlatformSignature);
             }
 
             final int variousFlags = read4Bytes("VariousFlags", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("VariousFlags", profileFileSignature);
             }
 
             final int deviceManufacturer = read4Bytes("DeviceManufacturer", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("DeviceManufacturer", deviceManufacturer);
             }
 
             final int deviceModel = read4Bytes("DeviceModel", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("DeviceModel", deviceModel);
             }
 
             skipBytes(is, 8, "Not a Valid ICC Profile");
 
             final int renderingIntent = read4Bytes("RenderingIntent", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("RenderingIntent", renderingIntent);
             }
 
             skipBytes(is, 12, "Not a Valid ICC Profile");
 
             final int profileCreatorSignature = read4Bytes("ProfileCreatorSignature", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("ProfileCreatorSignature", profileCreatorSignature);
             }
 
@@ -202,7 +198,7 @@ public class IccProfileParser extends BinaryFileParser {
             skipBytes(is, 16, "Not a Valid ICC Profile");
             // readByteArray("ProfileID", 16, is,
             // "Not a Valid ICC Profile");
-            // if (getDebug())
+            // if (LOGGER.isLoggable(Level.FINEST))
             // System.out
             // .println("ProfileID: '" + new String(ProfileID) + "'");
 
@@ -264,13 +260,13 @@ public class IccProfileParser extends BinaryFileParser {
                     deviceModel, renderingIntent, profileCreatorSignature,
                     profileId, tags);
 
-            if (getDebug()) {
-                Debug.debug("issRGB: " + result.issRGB());
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest("issRGB: " + result.issRGB());
             }
 
             return result;
         } catch (final Exception e) {
-            Debug.debug(e);
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
 
         return null;
@@ -299,15 +295,11 @@ public class IccProfileParser extends BinaryFileParser {
     }
 
     public boolean issRGB(final ByteSource byteSource) throws IOException {
-        if (getDebug()) {
-            Debug.debug();
-        }
-
         // setDebug(true);
 
         // long length = byteSource.getLength();
         //
-        // if (getDebug())
+        // if (LOGGER.isLoggable(Level.FINEST))
         // Debug.debug("length: " + length);
 
         try (InputStream is = byteSource.getInputStream()) {
@@ -323,12 +315,12 @@ public class IccProfileParser extends BinaryFileParser {
             skipBytes(is, 4 * 3);
 
             final int deviceManufacturer = read4Bytes("ProfileFileSignature", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("DeviceManufacturer", deviceManufacturer);
             }
 
             final int deviceModel = read4Bytes("DeviceModel", is, "Not a Valid ICC Profile", getByteOrder());
-            if (getDebug()) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 printCharQuad("DeviceModel", deviceModel);
             }
 

--- a/src/main/java/org/apache/commons/imaging/icc/IccTag.java
+++ b/src/main/java/org/apache/commons/imaging/icc/IccTag.java
@@ -19,17 +19,20 @@ package org.apache.commons.imaging.icc;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.BinaryFunctions;
 
 public class IccTag {
+
+    private static final Logger LOGGER = Logger.getLogger(IccTag.class.getName());
+
     public final int signature;
     public final int offset;
     public final int length;
@@ -73,11 +76,12 @@ public class IccTag {
     }
 
     public void dump(final String prefix) throws ImageReadException, IOException {
-        final PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-
-        dump(pw, prefix);
-
-        pw.flush();
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            dump(pw, prefix);
+            pw.flush();
+            sw.flush();
+            LOGGER.fine(sw.toString());
+        }
     }
 
     public void dump(final PrintWriter pw, final String prefix) throws ImageReadException,

--- a/src/main/java/org/apache/commons/imaging/icc/IccTagDataTypes.java
+++ b/src/main/java/org/apache/commons/imaging/icc/IccTagDataTypes.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageReadException;
 
@@ -42,7 +43,7 @@ public enum IccTagDataTypes implements IccTagDataType {
     
                 //            bis.readByteArray("ignore", bytes.length -12, "none");
                 final String s = new String(bytes, 12, stringLength - 1, StandardCharsets.US_ASCII);
-                System.out.println(prefix + "s: '" + s + "'");
+                LOGGER.fine(prefix + "s: '" + s + "'");
             }
         }
 
@@ -84,7 +85,7 @@ public enum IccTagDataTypes implements IccTagDataType {
                 read4Bytes("type_signature", bis, "ICC: corrupt tag data", ByteOrder.BIG_ENDIAN);
                 read4Bytes("ignore", bis, "ICC: corrupt tag data", ByteOrder.BIG_ENDIAN);
                 final int thesignature = read4Bytes("thesignature ", bis, "ICC: corrupt tag data", ByteOrder.BIG_ENDIAN);
-                System.out.println(prefix
+                LOGGER.fine(prefix
                         + "thesignature: "
                         + Integer.toHexString(thesignature)
                         + " ("
@@ -109,11 +110,13 @@ public enum IccTagDataTypes implements IccTagDataType {
                 read4Bytes("type_signature", bis, "ICC: corrupt tag data", ByteOrder.BIG_ENDIAN);
                 read4Bytes("ignore", bis, "ICC: corrupt tag data", ByteOrder.BIG_ENDIAN);
                 final String s = new String(bytes, 8, bytes.length - 8, StandardCharsets.US_ASCII);
-                System.out.println(prefix + "s: '" + s + "'");
+                LOGGER.fine(prefix + "s: '" + s + "'");
             }
         }
 
     };
+
+    private static final Logger LOGGER = Logger.getLogger(IccTagDataTypes.class.getName());
 
     public final String name;
     public final int signature;

--- a/src/main/java/org/apache/commons/imaging/internal/Debug.java
+++ b/src/main/java/org/apache/commons/imaging/internal/Debug.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.imaging.util;
+package org.apache.commons.imaging.internal;
 
 import java.awt.color.ICC_Profile;
 import java.io.File;
@@ -26,23 +26,32 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+/**
+ * Internal-only debug class. Used for collecting extra information when parsing or
+ * modifying images or metadata. These methods are useful for troubleshooting and
+ * issue analysis, but this should not be used directly by end-users, nor extended
+ * in any way. This may change or be removed at any time.
+ */
 public final class Debug {
 
-    private static final boolean DEBUG = false;
+    private static final Logger LOGGER = Logger.getLogger(Debug.class.getName());
+
     // public static String newline = System.getProperty("line.separator");
     private static final String NEWLINE = "\r\n";
     private static long counter;
 
     public static void debug(final String message) {
-        if (DEBUG) {
-            System.out.println(message);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(message);
         }
     }
 
     public static void debug() {
-        if (DEBUG) {
-            System.out.print(NEWLINE);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(NEWLINE);
         }
     }
 

--- a/src/main/java/org/apache/commons/imaging/internal/package-info.java
+++ b/src/main/java/org/apache/commons/imaging/internal/package-info.java
@@ -16,6 +16,6 @@
  */
 
 /**
- * Utility classes.
+ * Internal utility classes. These classes must not be used by users.
  */
-package org.apache.commons.imaging.util;
+package org.apache.commons.imaging.internal;

--- a/src/main/java/org/apache/commons/imaging/palette/ColorSpaceSubset.java
+++ b/src/main/java/org/apache/commons/imaging/palette/ColorSpaceSubset.java
@@ -18,8 +18,12 @@ package org.apache.commons.imaging.palette;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.logging.Logger;
 
 class ColorSpaceSubset {
+
+    private static final Logger LOGGER = Logger.getLogger(ColorSpaceSubset.class.getName());
+
     final int[] mins;
     final int[] maxs;
     final int precision;
@@ -89,29 +93,29 @@ class ColorSpaceSubset {
         final int bdiff = maxs[2] - mins[2] + 1;
         final int colorArea = rdiff * gdiff * bdiff;
 
-        System.out.println(prefix + ": [" + Integer.toHexString(rgb)
+        LOGGER.fine(prefix + ": [" + Integer.toHexString(rgb)
                 + "] total : " + total
         // + " ("
         // + (100.0 * (double) total / (double) total_area)
         // + " %)"
                 );
-        System.out.println("\t" + "rgb: " + Integer.toHexString(rgb) + ", "
+        LOGGER.fine("\t" + "rgb: " + Integer.toHexString(rgb) + ", "
                 + "red: " + Integer.toHexString(mins[0] << (8 - precision))
                 + ", " + Integer.toHexString(maxs[0] << (8 - precision)) + ", "
                 + "green: " + Integer.toHexString(mins[1] << (8 - precision))
                 + ", " + Integer.toHexString(maxs[1] << (8 - precision)) + ", "
                 + "blue: " + Integer.toHexString(mins[2] << (8 - precision))
                 + ", " + Integer.toHexString(maxs[2] << (8 - precision)));
-        System.out.println("\t" + "red: " + mins[0] + ", " + maxs[0] + ", "
+        LOGGER.fine("\t" + "red: " + mins[0] + ", " + maxs[0] + ", "
                 + "green: " + mins[1] + ", " + maxs[1] + ", " + "blue: "
                 + mins[2] + ", " + maxs[2]);
-        System.out.println("\t" + "rdiff: " + rdiff + ", " + "gdiff: " + gdiff
+        LOGGER.fine("\t" + "rdiff: " + rdiff + ", " + "gdiff: " + gdiff
                         + ", " + "bdiff: " + bdiff + ", " + "colorArea: "
                         + colorArea);
     }
 
     public void dumpJustRGB(final String prefix) {
-        System.out.println("\t" + "rgb: " + Integer.toHexString(rgb) + ", "
+        LOGGER.fine("\t" + "rgb: " + Integer.toHexString(rgb) + ", "
                 + "red: " + Integer.toHexString(mins[0] << (8 - precision))
                 + ", " + Integer.toHexString(maxs[0] << (8 - precision)) + ", "
                 + "green: " + Integer.toHexString(mins[1] << (8 - precision))

--- a/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
+++ b/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.imaging.ImageWriteException;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class MedianCutQuantizer {
     private final boolean ignoreAlpha;
@@ -83,15 +83,13 @@ public class MedianCutQuantizer {
     }
     
     public Palette process(final BufferedImage image, final int maxColors,
-            final MedianCut medianCut, final boolean verbose)
+            final MedianCut medianCut)
             throws ImageWriteException {
         final Map<Integer, ColorCount> colorMap = groupColors(image, maxColors);
 
         final int discreteColors = colorMap.keySet().size();
         if (discreteColors <= maxColors) {
-            if (verbose) {
-                Debug.debug("lossless palette: " + discreteColors);
-            }
+            Debug.debug("lossless palette: " + discreteColors);
 
             final int[] palette = new int[discreteColors];
             final List<ColorCount> colorCounts = new ArrayList<>(
@@ -108,9 +106,7 @@ public class MedianCutQuantizer {
             return new SimplePalette(palette);
         }
 
-        if (verbose) {
-            Debug.debug("discrete colors: " + discreteColors);
-        }
+        Debug.debug("discrete colors: " + discreteColors);
 
         final List<ColorGroup> colorGroups = new ArrayList<>();
         final ColorGroup root = new ColorGroup(new ArrayList<>(colorMap.values()), ignoreAlpha);
@@ -123,9 +119,7 @@ public class MedianCutQuantizer {
         }
 
         final int paletteSize = colorGroups.size();
-        if (verbose) {
-            Debug.debug("palette size: " + paletteSize);
-        }
+        Debug.debug("palette size: " + paletteSize);
 
         final int[] palette = new int[paletteSize];
 

--- a/src/main/java/org/apache/commons/imaging/palette/PaletteFactory.java
+++ b/src/main/java/org/apache/commons/imaging/palette/PaletteFactory.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.imaging.ImageWriteException;
 
@@ -32,7 +34,9 @@ import org.apache.commons.imaging.ImageWriteException;
  * Factory for creating palettes.
  */
 public class PaletteFactory {
-    private static final boolean DEBUG = false;
+
+    private static final Logger LOGGER = Logger.getLogger(PaletteFactory.class.getName());
+
     public static final int COMPONENTS = 3; // in bits
     
     /**
@@ -66,8 +70,8 @@ public class PaletteFactory {
             count += Integer.bitCount(eight);
         }
 
-        if (DEBUG) {
-            System.out.println("Used colors: " + count);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("Used colors: " + count);
         }
 
         final int[] colormap = new int[count];
@@ -127,7 +131,7 @@ public class PaletteFactory {
 
     private DivisionCandidate finishDivision(final ColorSpaceSubset subset,
             final int component, final int precision, final int sum, final int slice) {
-        if (DEBUG) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
             subset.dump("trying (" + component + "): ");
         }
 
@@ -155,13 +159,13 @@ public class PaletteFactory {
         sliceMaxs[component] = slice;
         sliceMins[component] = slice + 1;
 
-        if (DEBUG) {
-            System.out.println("total: " + total);
-            System.out.println("first total: " + sum);
-            System.out.println("second total: " + (total - sum));
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("total: " + total);
+            LOGGER.finest("first total: " + sum);
+            LOGGER.finest("second total: " + (total - sum));
             // System.out.println("start: " + start);
             // System.out.println("end: " + end);
-            System.out.println("slice: " + slice);
+            LOGGER.finest("slice: " + slice);
 
         }
 
@@ -174,7 +178,7 @@ public class PaletteFactory {
 
     private List<DivisionCandidate> divideSubset2(final int[] table,
             final ColorSpaceSubset subset, final int component, final int precision) {
-        if (DEBUG) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
             subset.dump("trying (" + component + "): ");
         }
 
@@ -291,8 +295,8 @@ public class PaletteFactory {
             if (maxSubset == null) {
                 return v;
             }
-            if (DEBUG) {
-                System.out.println("\t" + "area: " + maxArea);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest("\t" + "area: " + maxArea);
             }
 
             final DivisionCandidate dc = divideSubset2(table, maxSubset,
@@ -334,9 +338,9 @@ public class PaletteFactory {
         final ColorSpaceSubset all = new ColorSpaceSubset(width * height, precision);
         subsets.add(all);
 
-        if (DEBUG) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
             final int preTotal = getFrequencyTotal(table, all.mins, all.maxs, precision);
-            System.out.println("pre total: " + preTotal);
+            LOGGER.finest("pre total: " + preTotal);
         }
 
         // step 1: count frequency of colors
@@ -350,17 +354,17 @@ public class PaletteFactory {
             }
         }
 
-        if (DEBUG) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
             final int allTotal = getFrequencyTotal(table, all.mins, all.maxs, precision);
-            System.out.println("all total: " + allTotal);
-            System.out.println("width * height: " + (width * height));
+            LOGGER.finest("all total: " + allTotal);
+            LOGGER.finest("width * height: " + (width * height));
         }
 
         subsets = divide(subsets, max, table, precision);
 
-        if (DEBUG) {
-            System.out.println("subsets: " + subsets.size());
-            System.out.println("width*height: " + width * height);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("subsets: " + subsets.size());
+            LOGGER.finest("width*height: " + width * height);
         }
 
         for (int i = 0; i < subsets.size(); i++) {
@@ -368,7 +372,7 @@ public class PaletteFactory {
 
             subset.setAverageRGB(table);
 
-            if (DEBUG) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 subset.dump(i + ": ");
             }
         }
@@ -390,7 +394,7 @@ public class PaletteFactory {
      */
     public Palette makeQuantizedRgbaPalette(final BufferedImage src, final boolean transparent, final int max) throws ImageWriteException {
         return new MedianCutQuantizer(!transparent).process(src, max,
-                new LongestAxisMedianCut(), false);
+                new LongestAxisMedianCut());
     }
 
     /**

--- a/src/test/java/org/apache/commons/imaging/ImagingTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImagingTest.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.imaging.test.util.FileSystemTraversal;
-import org.apache.commons.imaging.util.Debug;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 

--- a/src/test/java/org/apache/commons/imaging/color/ColorConversionsTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorConversionsTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.imaging.color;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class ColorConversionsTest {

--- a/src/test/java/org/apache/commons/imaging/common/RationalNumberTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/RationalNumberTest.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.imaging.ImagingTest;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceImageTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceImageTest.java
@@ -38,7 +38,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
@@ -29,7 +29,7 @@ import java.nio.ByteOrder;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.BinaryOutputStream;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
@@ -32,7 +32,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.BinaryOutputStream;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifDumpTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegUtils;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -47,7 +47,7 @@ import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.fieldtypes.FieldType;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/GpsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/GpsTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MakerNoteFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MakerNoteFieldTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class MakerNoteFieldTest extends SpecificExifTagTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 
 public class TextFieldTest extends SpecificExifTagTest {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.imaging.examples.WriteExifMetadataExample;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcDumpTest.java
@@ -29,7 +29,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegPhotoshopMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class ConvertPngToGifTest extends PngBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class PngWriteForceTrueColorText extends PngBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class RgbeReadTest extends RgbeBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/JpegImageDataTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/JpegImageDataTest.java
@@ -26,7 +26,7 @@ public class JpegImageDataTest{
     public void testCreatesJpegImageDataAndCallsGetElementDescription() {
         byte[] byteArray = new byte[5];
         JpegImageData jpegImageData = new JpegImageData((-1L), 1, byteArray);
-        String string = jpegImageData.getElementDescription(true);
+        String string = jpegImageData.getElementDescription();
 
         assertEquals("Jpeg image data: 5 bytes", string);
     }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffCcittTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffCcittTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.itu_t4.T4AndT6Compression;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class TiffCcittTest extends TiffBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffLzwTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffLzwTest.java
@@ -34,7 +34,7 @@ import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.common.mylzw.MyLzwCompressor;
 import org.apache.commons.imaging.common.mylzw.MyLzwDecompressor;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class TiffReadTest extends TiffBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class TiffRoundtripTest extends TiffBaseTest {

--- a/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpDumpTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingTest;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class XmpDumpTest extends ImagingTest {

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.ImagingTest;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Test;
 
 public class XmpUpdateTest extends ImagingTest {

--- a/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/org/apache/commons/imaging/palette/PaletteQuantizationTest.java
+++ b/src/test/java/org/apache/commons/imaging/palette/PaletteQuantizationTest.java
@@ -95,7 +95,7 @@ public class PaletteQuantizationTest extends ImagingTest {
         
         final MedianCutQuantizer medianCutQuantizer = new MedianCutQuantizer(true);
         palette = medianCutQuantizer.process(
-                image, limit, new MostPopulatedBoxesMedianCut(), false);
+                image, limit, new MostPopulatedBoxesMedianCut());
         assertEquals(expectedSize, palette.length());
         checkUniqueColors(image, palette);
         if (exact) {

--- a/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
@@ -23,7 +23,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -27,7 +27,7 @@ import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.RgbBufferedImageFactory;
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 

--- a/src/test/java/org/apache/commons/imaging/test/util/FileSystemTraversal.java
+++ b/src/test/java/org/apache/commons/imaging/test/util/FileSystemTraversal.java
@@ -18,7 +18,7 @@ package org.apache.commons.imaging.test.util;
 
 import java.io.File;
 
-import org.apache.commons.imaging.util.Debug;
+import org.apache.commons.imaging.internal.Debug;
 
 public class FileSystemTraversal {
 


### PR DESCRIPTION
Removed the `Debug` and `ImageDump` classes. Also removed methods with the `verbose` parameter, as well as any `System.out.println`'s. Tried to keep the change to a minimum, but given the extent of its use, I believe the pull request diff will be a bit long.