### PR TITLE
Avoid jpeg parse fail due to jfxx and exif

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegConstants.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegConstants.java
@@ -40,6 +40,13 @@ public final class JpegConstants {
                     0x46, // F
                     0x20, //
             });
+    public static final BinaryConstant JFXX0_EXTENSION_SIGNATURE = new BinaryConstant(
+            new byte[] { 0x4a, // J
+                    0x46, // F
+                    0x58, // X
+                    0x58, // X
+                    0x0, //
+            });
 
     public static final BinaryConstant EXIF_IDENTIFIER_CODE = new BinaryConstant(
             new byte[] { 0x45, // E

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -312,7 +312,12 @@ public class JpegImageParser extends ImageParser {
     @Override
     public ImageMetadata getMetadata(final ByteSource byteSource, final Map<String, Object> params)
             throws ImageReadException, IOException {
-        final TiffImageMetadata exif = getExifMetadata(byteSource, params);
+        TiffImageMetadata exif = null;
+        try {
+            exif = getExifMetadata(byteSource, params);
+        } catch (Exception e) {
+            // exif parse failed.
+        }
 
         final JpegPhotoshopMetadata photoshop = getPhotoshopMetadata(byteSource,
                 params);

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegment.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegment.java
@@ -52,7 +52,8 @@ public class JfifSegment extends Segment {
 
         final byte[] signature = readBytes(is, JpegConstants.JFIF0_SIGNATURE.size());
         if (!JpegConstants.JFIF0_SIGNATURE.equals(signature)
-                && !JpegConstants.JFIF0_SIGNATURE_ALTERNATIVE.equals(signature)) {
+                && !JpegConstants.JFIF0_SIGNATURE_ALTERNATIVE.equals(signature)
+                && !JpegConstants.JFXX0_EXTENSION_SIGNATURE.equals(signature)) {
             throw new ImageReadException(
                     "Not a Valid JPEG File: missing JFIF string");
         }


### PR DESCRIPTION
- add jfxx signature when parsing jpeg
- Avoid jpeg parse fail due to exif