### PR TITLE
[IMAGING-228] Drop cube method and add unit tests for PhotometricInterpretationLogLuv

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2019-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-228" dev="kinow" type="add">
+        Remove private method PhotometricInterpreterLogLuv#cube by Math.pow
+      </action>
       <action issue="IMAGING-224" dev="kinow" type="fix">
         Fix build errors in Travis
       </action>

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreter.java
@@ -26,7 +26,9 @@ import org.apache.commons.imaging.common.ImageBuilder;
  * interpretation tag is a requirement for valid TIFF images, and defines the
  * color space of the image data.
  *
- * @see https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html
+ * @see <a href=
+ *      "https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html">
+ *      Baseline TIFF Tag PhotometricInterpretation </a>
  */
 public abstract class PhotometricInterpreter {
     protected final int samplesPerPixel;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreter.java
@@ -21,6 +21,13 @@ import java.io.IOException;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 
+/**
+ * Interpreter for photometric information in TIFF images. The photometric
+ * interpretation tag is a requirement for valid TIFF images, and defines the
+ * color space of the image data.
+ *
+ * @see https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html
+ */
 public abstract class PhotometricInterpreter {
     protected final int samplesPerPixel;
     private final int[] bitsPerSample;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -27,20 +27,15 @@ import org.apache.commons.imaging.common.ImageBuilder;
  * @see https://en.wikipedia.org/wiki/Logluv_TIFF
  */
 public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
-    // private final boolean yOnly;
 
     public PhotometricInterpreterLogLuv(final int samplesPerPixel,
             final int[] bitsPerSample, final int predictor, final int width, final int height) {
         super(samplesPerPixel, bitsPerSample, predictor, width, height);
-
-        // this.yOnly = yonly;
     }
 
     private float cube(final float f) {
         return f * f * f;
     }
-
-    // private float function_f(float value, )
 
     @Override
     public void interpretPixel(final ImageBuilder imageBuilder, final int[] samples, final int x,
@@ -120,11 +115,6 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
                 var_B = 12.92f * var_B;
             }
 
-            // var_R = (((var_R-)))
-            // updateMaxMin(new float[]{
-            // var_R, var_G, var_B,
-            // }, maxVarRGB, minVarRGB);
-
             // var_R = ((var_R + 0.16561039f) / (3.0152583f + 0.16561039f));
             // var_G = ((var_G + 0.06561642f) / (3.0239854f + 0.06561642f));
             // var_B = ((var_B + 0.19393992f) / (3.1043448f + 0.19393992f));
@@ -137,10 +127,6 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         // float R = 1.910f * X - 0.532f * Y - 0.288f * Z;
         // float G = -0.985f * X + 1.999f * Y - 0.028f * Z;
         // float B = 0.058f * X - 0.118f * Y + 0.898f * Z;
-
-        // updateMaxMin(new float[]{
-        // R, G, B,
-        // }, maxRGB, minRGB);
 
         int red = R;
         int green = G;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -52,10 +52,6 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         super(samplesPerPixel, bitsPerSample, predictor, width, height);
     }
 
-    private float cube(final float f) {
-        return f * f * f;
-    }
-
     @Override
     public void interpretPixel(final ImageBuilder imageBuilder, final int[] samples, final int x,
             final int y) throws ImageReadException, IOException {
@@ -107,9 +103,9 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         float var_X = cieA / 500.0f + var_Y;
         float var_Z = var_Y - cieB / 200.0f;
 
-        final float var_x_cube = cube(var_X);
-        final float var_y_cube = cube(var_Y);
-        final float var_z_cube = cube(var_Z);
+        final float var_x_cube = (float) Math.pow(var_X, 3.0d);
+        final float var_y_cube = (float) Math.pow(var_Y, 3.0d);
+        final float var_z_cube = (float) Math.pow(var_Z, 3.0d);
 
         if (var_y_cube > 0.008856f) {
             var_Y = var_y_cube;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -40,6 +40,9 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
     @Override
     public void interpretPixel(final ImageBuilder imageBuilder, final int[] samples, final int x,
             final int y) throws ImageReadException, IOException {
+        if (samples == null || samples.length != 3) {
+            throw new ImageReadException("Invalid length of bits per sample (expected 3).");
+        }
         float X, Y, Z;
 
         final int cieL = samples[0];

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -21,6 +21,11 @@ import java.io.IOException;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 
+/**
+ * Photometric interpretation Logluv support. Logluv is an encoding for storing data inside TIFF images.
+ *
+ * @see https://en.wikipedia.org/wiki/Logluv_TIFF
+ */
 public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
     // private final boolean yOnly;
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -22,11 +22,30 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 
 /**
- * Photometric interpretation Logluv support. Logluv is an encoding for storing data inside TIFF images.
+ * Photometric interpretation Logluv support. Logluv is an encoding for storing
+ * data inside TIFF images.
  *
- * @see https://en.wikipedia.org/wiki/Logluv_TIFF
+ * @see <a href="https://en.wikipedia.org/wiki/Logluv_TIFF">Logluv TIFF</a>
  */
 public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
+
+    /**
+     * Tristimulus color values (red-green-blue, as X-Y-Z, in the CIE XYZ color space).
+     */
+    private static class TristimulusValues {
+        public float x;
+        public float y;
+        public float z;
+    }
+
+    /**
+     * Rgb values (reg-green-blue, as R-G-B, as in the RGB color model).
+     */
+    private static class RgbValues {
+        public int r;
+        public int g;
+        public int b;
+    }
 
     public PhotometricInterpreterLogLuv(final int samplesPerPixel,
             final int[] bitsPerSample, final int predictor, final int width, final int height) {
@@ -43,98 +62,131 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         if (samples == null || samples.length != 3) {
             throw new ImageReadException("Invalid length of bits per sample (expected 3).");
         }
-        float X, Y, Z;
 
+        // CIE illuminants. An illuminant is a theorical source of visible light with a profile.
+        // CIE stands for Commission Internationale de l'Eclairage, or International
+        // Comission on Illumination.
         final int cieL = samples[0];
         final int cieA = (byte) samples[1];
         final int cieB = (byte) samples[2];
 
-        {
-            float var_Y = ((cieL * 100.0f / 255.0f) + 16.0f) / 116.0f;
-            float var_X = cieA / 500.0f + var_Y;
-            float var_Z = var_Y - cieB / 200.0f;
-
-            final float var_x_cube = cube(var_X);
-            final float var_y_cube = cube(var_Y);
-            final float var_z_cube = cube(var_Z);
-
-            if (var_y_cube > 0.008856f) {
-                var_Y = var_y_cube;
-            } else {
-                var_Y = (var_Y - 16 / 116.0f) / 7.787f;
-            }
-
-            if (var_x_cube > 0.008856f) {
-                var_X = var_x_cube;
-            } else {
-                var_X = (var_X - 16 / 116.0f) / 7.787f;
-            }
-
-            if (var_z_cube > 0.008856f) {
-                var_Z = var_z_cube;
-            } else {
-                var_Z = (var_Z - 16 / 116.0f) / 7.787f;
-            }
-
-            final float ref_X = 95.047f;
-            final float ref_Y = 100.000f;
-            final float ref_Z = 108.883f;
-
-            X = ref_X * var_X; // ref_X = 95.047 Observer= 2°, Illuminant= D65
-            Y = ref_Y * var_Y; // ref_Y = 100.000
-            Z = ref_Z * var_Z; // ref_Z = 108.883
-        }
+        final TristimulusValues tristimulusValues = getTristimulusValues(cieL, cieA, cieB);
 
         // ref_X = 95.047 //Observer = 2°, Illuminant = D65
         // ref_Y = 100.000
         // ref_Z = 108.883
 
-        int R, G, B;
-        {
-            final float var_X = X / 100f; // X = From 0 to ref_X
-            final float var_Y = Y / 100f; // Y = From 0 to ref_Y
-            final float var_Z = Z / 100f; // Z = From 0 to ref_Y
-
-            float var_R = var_X * 3.2406f + var_Y * -1.5372f + var_Z * -0.4986f;
-            float var_G = var_X * -0.9689f + var_Y * 1.8758f + var_Z * 0.0415f;
-            float var_B = var_X * 0.0557f + var_Y * -0.2040f + var_Z * 1.0570f;
-
-            if (var_R > 0.0031308) {
-                var_R = 1.055f * (float) Math.pow(var_R, (1 / 2.4)) - 0.055f;
-            } else {
-                var_R = 12.92f * var_R;
-            }
-            if (var_G > 0.0031308) {
-                var_G = 1.055f * (float) Math.pow(var_G, (1 / 2.4)) - 0.055f;
-            } else {
-                var_G = 12.92f * var_G;
-            }
-
-            if (var_B > 0.0031308) {
-                var_B = 1.055f * (float) Math.pow(var_B, (1 / 2.4)) - 0.055f;
-            } else {
-                var_B = 12.92f * var_B;
-            }
-
-            // var_R = ((var_R + 0.16561039f) / (3.0152583f + 0.16561039f));
-            // var_G = ((var_G + 0.06561642f) / (3.0239854f + 0.06561642f));
-            // var_B = ((var_B + 0.19393992f) / (3.1043448f + 0.19393992f));
-
-            R = (int) (var_R * 255f);
-            G = (int) (var_G * 255f);
-            B = (int) (var_B * 255f);
-        }
+        final RgbValues rgbValues = getRgbValues(tristimulusValues);
 
         // float R = 1.910f * X - 0.532f * Y - 0.288f * Z;
         // float G = -0.985f * X + 1.999f * Y - 0.028f * Z;
         // float B = 0.058f * X - 0.118f * Y + 0.898f * Z;
 
-        final int red = Math.min(255, Math.max(0, R));
-        final int green = Math.min(255, Math.max(0, G));
-        final int blue = Math.min(255, Math.max(0, B));
+        final int red = Math.min(255, Math.max(0, rgbValues.r));
+        final int green = Math.min(255, Math.max(0, rgbValues.g));
+        final int blue = Math.min(255, Math.max(0, rgbValues.b));
         final int alpha = 0xff;
         final int rgb = (alpha << 24) | (red << 16) | (green << 8) | (blue << 0);
         imageBuilder.setRGB(x, y, rgb);
 
+    }
+
+    /**
+     * Receives a triplet of CIELAB values, and calculates the tristimulus values.
+     * The reference white point used here is the equivalent to summer sun and sky.
+     *
+     * @param cieL lightness from black to white
+     * @param cieA lightness from green to red
+     * @param cieB lightness from blue to yellow
+     * @return tristimulus (X, Y, and Z) values
+     * @see <a href="https://en.wikipedia.org/wiki/CIELAB_color_space">CIELAB color space</a>
+     * @see <a href="https://en.wikipedia.org/wiki/White_point">White point</a>
+     */
+    private TristimulusValues getTristimulusValues(int cieL, int cieA, int cieB) {
+        float var_Y = ((cieL * 100.0f / 255.0f) + 16.0f) / 116.0f;
+        float var_X = cieA / 500.0f + var_Y;
+        float var_Z = var_Y - cieB / 200.0f;
+
+        final float var_x_cube = cube(var_X);
+        final float var_y_cube = cube(var_Y);
+        final float var_z_cube = cube(var_Z);
+
+        if (var_y_cube > 0.008856f) {
+            var_Y = var_y_cube;
+        } else {
+            var_Y = (var_Y - 16 / 116.0f) / 7.787f;
+        }
+
+        if (var_x_cube > 0.008856f) {
+            var_X = var_x_cube;
+        } else {
+            var_X = (var_X - 16 / 116.0f) / 7.787f;
+        }
+
+        if (var_z_cube > 0.008856f) {
+            var_Z = var_z_cube;
+        } else {
+            var_Z = (var_Z - 16 / 116.0f) / 7.787f;
+        }
+
+        // These reference values are the relative white points (XYZ) for commons scene types.
+        // The chosen values here reflect a scene with Summer Sun and Sky, temperature of 6504 K,
+        // X 95.047, Y 100.0, and Z 108.883.
+        // See Color Science by Wyszecki and Stiles for more
+        final float ref_X = 95.047f;
+        final float ref_Y = 100.000f;
+        final float ref_Z = 108.883f;
+
+        final TristimulusValues values = new TristimulusValues();
+        values.x = ref_X * var_X; // ref_X = 95.047 Observer= 2°, Illuminant= D65
+        values.y = ref_Y * var_Y; // ref_Y = 100.000
+        values.z = ref_Z * var_Z; // ref_Z = 108.883
+        return values;
+    }
+
+    /**
+     * Receives a triplet tristimulus values (CIE XYZ) and then does a CIELAB-CIEXYZ
+     * conversion (consult Wikipedia link for formula), where the CIELAB values are
+     * used to calculate the tristimulus values of the reference white point.
+     *
+     * @param tristimulusValues the XYZ tristimulus values
+     * @return RGB values
+     * @see <a href="https://en.wikipedia.org/wiki/CIELAB_color_space">CIELAB color space</a>
+     */
+    private RgbValues getRgbValues(TristimulusValues tristimulusValues) {
+        final float var_X = tristimulusValues.x / 100f; // X = From 0 to ref_X
+        final float var_Y = tristimulusValues.y / 100f; // Y = From 0 to ref_Y
+        final float var_Z = tristimulusValues.z / 100f; // Z = From 0 to ref_Y
+
+        float var_R = var_X * 3.2406f + var_Y * -1.5372f + var_Z * -0.4986f;
+        float var_G = var_X * -0.9689f + var_Y * 1.8758f + var_Z * 0.0415f;
+        float var_B = var_X * 0.0557f + var_Y * -0.2040f + var_Z * 1.0570f;
+
+        if (var_R > 0.0031308) {
+            var_R = 1.055f * (float) Math.pow(var_R, (1 / 2.4)) - 0.055f;
+        } else {
+            var_R = 12.92f * var_R;
+        }
+        if (var_G > 0.0031308) {
+            var_G = 1.055f * (float) Math.pow(var_G, (1 / 2.4)) - 0.055f;
+        } else {
+            var_G = 12.92f * var_G;
+        }
+
+        if (var_B > 0.0031308) {
+            var_B = 1.055f * (float) Math.pow(var_B, (1 / 2.4)) - 0.055f;
+        } else {
+            var_B = 12.92f * var_B;
+        }
+
+        // var_R = ((var_R + 0.16561039f) / (3.0152583f + 0.16561039f));
+        // var_G = ((var_G + 0.06561642f) / (3.0239854f + 0.06561642f));
+        // var_B = ((var_B + 0.19393992f) / (3.1043448f + 0.19393992f));
+
+        final RgbValues values = new RgbValues();
+        values.r = (int) (var_R * 255f);
+        values.g = (int) (var_G * 255f);
+        values.b = (int) (var_B * 255f);
+        return values;
     }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -32,7 +32,7 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
     /**
      * Tristimulus color values (red-green-blue, as X-Y-Z, in the CIE XYZ color space).
      */
-    private static class TristimulusValues {
+    static class TristimulusValues {
         public float x;
         public float y;
         public float z;
@@ -41,7 +41,7 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
     /**
      * Rgb values (reg-green-blue, as R-G-B, as in the RGB color model).
      */
-    private static class RgbValues {
+    static class RgbValues {
         public int r;
         public int g;
         public int b;
@@ -102,7 +102,7 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
      * @see <a href="https://en.wikipedia.org/wiki/CIELAB_color_space">CIELAB color space</a>
      * @see <a href="https://en.wikipedia.org/wiki/White_point">White point</a>
      */
-    private TristimulusValues getTristimulusValues(int cieL, int cieA, int cieB) {
+    TristimulusValues getTristimulusValues(int cieL, int cieA, int cieB) {
         float var_Y = ((cieL * 100.0f / 255.0f) + 16.0f) / 116.0f;
         float var_X = cieA / 500.0f + var_Y;
         float var_Z = var_Y - cieB / 200.0f;
@@ -153,7 +153,7 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
      * @return RGB values
      * @see <a href="https://en.wikipedia.org/wiki/CIELAB_color_space">CIELAB color space</a>
      */
-    private RgbValues getRgbValues(TristimulusValues tristimulusValues) {
+    RgbValues getRgbValues(TristimulusValues tristimulusValues) {
         final float var_X = tristimulusValues.x / 100f; // X = From 0 to ref_X
         final float var_Y = tristimulusValues.y / 100f; // Y = From 0 to ref_Y
         final float var_Z = tristimulusValues.z / 100f; // Z = From 0 to ref_Y

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuv.java
@@ -47,7 +47,6 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         final int cieB = (byte) samples[2];
 
         {
-
             float var_Y = ((cieL * 100.0f / 255.0f) + 16.0f) / 116.0f;
             float var_X = cieA / 500.0f + var_Y;
             float var_Z = var_Y - cieB / 200.0f;
@@ -81,7 +80,6 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
             X = ref_X * var_X; // ref_X = 95.047 Observer= 2°, Illuminant= D65
             Y = ref_Y * var_Y; // ref_Y = 100.000
             Z = ref_Z * var_Z; // ref_Z = 108.883
-
         }
 
         // ref_X = 95.047 //Observer = 2°, Illuminant = D65
@@ -128,13 +126,9 @@ public class PhotometricInterpreterLogLuv extends PhotometricInterpreter {
         // float G = -0.985f * X + 1.999f * Y - 0.028f * Z;
         // float B = 0.058f * X - 0.118f * Y + 0.898f * Z;
 
-        int red = R;
-        int green = G;
-        int blue = B;
-
-        red = Math.min(255, Math.max(0, red));
-        green = Math.min(255, Math.max(0, green));
-        blue = Math.min(255, Math.max(0, blue));
+        final int red = Math.min(255, Math.max(0, R));
+        final int green = Math.min(255, Math.max(0, G));
+        final int blue = Math.min(255, Math.max(0, B));
         final int alpha = 0xff;
         final int rgb = (alpha << 24) | (red << 16) | (green << 8) | (blue << 0);
         imageBuilder.setRGB(x, y, rgb);

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -18,19 +18,27 @@ package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class PhotometricInterpreterLogLuvTest {
 
+    private PhotometricInterpreterLogLuv p;
+
+    private int samplesPerPixel = 8;
+    private int[] bitsPerSample = new int[] {1, 2, 3};
+    private int predictor = 1;
+    private int width = 800;
+    private int height = 600;
+
+    @Before
+    public void setUp() {
+        p = new PhotometricInterpreterLogLuv(samplesPerPixel, bitsPerSample, predictor,
+                width, height);
+    }
+
     @Test
     public void testConstructor() {
-        int samplesPerPixel = 8;
-        int[] bitsPerSample = new int[] {1, 2, 3};
-        int predictor = 1;
-        int width = 800;
-        int height = 600;
-        PhotometricInterpreterLogLuv p = new PhotometricInterpreterLogLuv(samplesPerPixel, bitsPerSample, predictor,
-                width, height);
         assertEquals(samplesPerPixel, p.samplesPerPixel);
         for (int i = 0; i < bitsPerSample.length; i++) {
             assertEquals(bitsPerSample[i], p.getBitsPerSample(i));
@@ -38,5 +46,21 @@ public class PhotometricInterpreterLogLuvTest {
         assertEquals(predictor, p.predictor);
         assertEquals(width, p.width);
         assertEquals(height, p.height);
+    }
+
+    @Test
+    public void testGetTristimulusValues() {
+        // any value equals 0 will have its pow(N, 3) equal to 0
+        assertEquals(0.0d, (double) p.getTristimulusValues(0, 0, 0).x, 0.001d);
+        assertEquals(0.0d, (double) p.getTristimulusValues(0, 0, 0).y, 0.001d);
+        assertEquals(0.0d, (double) p.getTristimulusValues(0, 0, 0).z, 0.001d);
+        // values under the threshold used in the if statements
+        assertEquals(0.04126d, (double) p.getTristimulusValues(1, 0, 0).x, 0.001d);
+        assertEquals(0.04341d, (double) p.getTristimulusValues(1, 0, 0).y, 0.001d);
+        assertEquals(0.04727d, (double) p.getTristimulusValues(1, 0, 0).z, 0.001d);
+        // values under the threshold used in the if statements
+        assertEquals(29.36116d, (double) p.getTristimulusValues(100, 100, 50).x, 0.001d);
+        assertEquals(10.78483d, (double) p.getTristimulusValues(100, 100, 50).y, 0.001d);
+        assertEquals(1.25681d, (double) p.getTristimulusValues(100, 100, 50).z, 0.001d);
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -18,6 +18,10 @@ package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+
+import org.apache.commons.imaging.ImageReadException;
+import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterLogLuv.TristimulusValues;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,5 +85,24 @@ public class PhotometricInterpreterLogLuvTest {
         assertEquals(28, p.getRgbValues(triValues).r);
         assertEquals(24, p.getRgbValues(triValues).g);
         assertEquals(23, p.getRgbValues(triValues).b);
+    }
+
+    @Test(expected=ImageReadException.class)
+    public void testInterpretPixelNullSamples() throws ImageReadException, IOException {
+        p.interpretPixel(null, null, 0, 0);
+    }
+
+    @Test(expected=ImageReadException.class)
+    public void testInterpretPixelEmptySamples() throws ImageReadException, IOException {
+        p.interpretPixel(null, new int[] {}, 0, 0);
+    }
+
+    @Test
+    public void testInterpretPixel() throws ImageReadException, IOException {
+        ImageBuilder imgBuilder = new ImageBuilder(600, 400, /*alpha*/ true);
+        int x = 10;
+        int y = 20;
+        p.interpretPixel(imgBuilder, new int[] {100, (byte) 32, (byte) 2}, x, y);
+        assertEquals(-7584166, imgBuilder.getRGB(x, y));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class PhotometricInterpreterLogLuvTest {
+
+    @Test
+    public void testConstructor() {
+        int samplesPerPixel = 8;
+        int[] bitsPerSample = new int[] {1, 2, 3};
+        int predictor = 1;
+        int width = 800;
+        int height = 600;
+        PhotometricInterpreterLogLuv p = new PhotometricInterpreterLogLuv(samplesPerPixel, bitsPerSample, predictor,
+                width, height);
+        assertEquals(samplesPerPixel, p.samplesPerPixel);
+        for (int i = 0; i < bitsPerSample.length; i++) {
+            assertEquals(bitsPerSample[i], p.getBitsPerSample(i));
+        }
+        assertEquals(predictor, p.predictor);
+        assertEquals(width, p.width);
+        assertEquals(height, p.height);
+    }
+}

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterLogLuv.TristimulusValues;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,5 +63,23 @@ public class PhotometricInterpreterLogLuvTest {
         assertEquals(29.36116d, (double) p.getTristimulusValues(100, 100, 50).x, 0.001d);
         assertEquals(10.78483d, (double) p.getTristimulusValues(100, 100, 50).y, 0.001d);
         assertEquals(1.25681d, (double) p.getTristimulusValues(100, 100, 50).z, 0.001d);
+    }
+
+    @Test
+    public void testGetRgbValues() {
+        // any value equals 0 will have its pow(N, 3) equal to 0
+        TristimulusValues triValues = new TristimulusValues();
+        triValues.x = 0;
+        triValues.y = 0;
+        triValues.z = 0;
+        assertEquals(0, p.getRgbValues(triValues).r);
+        assertEquals(0, p.getRgbValues(triValues).g);
+        assertEquals(0, p.getRgbValues(triValues).b);
+        triValues.x = 1;
+        triValues.y = 1;
+        triValues.z = 1;
+        assertEquals(28, p.getRgbValues(triValues).r);
+        assertEquals(24, p.getRgbValues(triValues).g);
+        assertEquals(23, p.getRgbValues(triValues).b);
     }
 }


### PR DESCRIPTION
Noticed that the `PhotometricInterpretaterLogLuv` had no coverage, so decided to write some simple unit tests.

Then found a `cube` method that can be replaced by `Math.pow(N, 3)`, and also that there is no javadocs about what is XYZ, why LAB, what is CIE, or even what is Photometric Interpretation.