### PR TITLE
Disable clirr report for now (alpha releases)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
   <inceptionYear>2007</inceptionYear>
 
   <build>
-    <defaultGoal>clean verify apache-rat:check clirr:check checkstyle:check findbugs:check javadoc:javadoc</defaultGoal>
+    <defaultGoal>clean verify apache-rat:check checkstyle:check findbugs:check javadoc:javadoc</defaultGoal>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
There are pull requests which Travis jobs are failing due to clirr check goal failures.

We have renamed methods `getFilename` to `getFileName`, which breaks backward compatibility. That's, however, acceptable given we are working on an 1.0-alpha release series.

So I suggest we disable in Travis-CI Clirr checks for now, by simply removing `clirr:check` from the Maven default goal in the project `pom.xml`.

Cheers
Bruno