### PR TITLE
IMAGING-230: Properly close resources with try-with-resources

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2019-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-230" dev="kinow" type="fix">
+        Properly close resources with try-with-resources in T4AndT6Compression
+      </action>
       <action issue="IMAGING-134" dev="kinow" type="fix" due-to="Michael Sommerville">
         Invalid (RST) marker found in entropy data
       </action>


### PR DESCRIPTION
Just wrapped the code around a try in one method, and in the other one created two resources instead of one (properly closed) that received another (not properly closed) as constructor argument.
