### PR TITLE
Fix javadoc for Java 13 (heading out of order)

### DIFF
--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -60,16 +60,16 @@ import org.apache.commons.imaging.formats.xpm.XpmImageParser;
  * own specific format.   Specific implementations are found
  * under the com.apache.commons.imaging.formats package.
  *
- * <h3>Application Notes</h3>
+ * <h2>Application Notes</h2>
  *
- * <h4>Format support</h4>
+ * <h3>Format support</h3>
  *
  * For the most recent information on format support for the
  * Apache Commons Imaging package, refer to
  * <a href="https://commons.apache.org/imaging/formatsupport.html">Format Support</a>
  * at the main project development web site.
  *
- * <h4>On the accuracy of this Javadoc</h4>
+ * <h3>On the accuracy of this Javadoc</h3>
  *
  * The original authors of this class did not supply documentation.
  * The Javadoc for this class is based on inspection of the
@@ -79,7 +79,7 @@ import org.apache.commons.imaging.formats.xpm.XpmImageParser;
  * that the documentation is perfect, especially in the more obscure
  * and specialized areas of implementation.
  *
- * <h4>The "Map params" argument</h4>
+ * <h3>The "Map params" argument</h3>
  *
  * Many of the methods specified by this class accept an argument of
  * type Map giving a list of parameters to be used when processing an

--- a/src/main/java/org/apache/commons/imaging/Imaging.java
+++ b/src/main/java/org/apache/commons/imaging/Imaging.java
@@ -45,9 +45,9 @@ import org.apache.commons.imaging.icc.IccProfileParser;
 /**
  * The primary application programming interface (API) to the Imaging library.
  *
- * <h3>Application Notes</h3>
+ * <h2>Application Notes</h2>
  *
- * <h4>Using this class</h4>
+ * <h3>Using this class</h3>
  *
  * <p>
  * Almost all of the Apache Commons Imaging library's core functionality can
@@ -65,7 +65,7 @@ import org.apache.commons.imaging.icc.IccProfileParser;
  * The Apache Commons Imaging package is a pure Java implementation.
  * </p>
  *
- * <h4>Format support</h4>
+ * <h3>Format support</h3>
  *
  * <p>
  * While the Apache Commons Imaging package handles a number of different
@@ -75,7 +75,7 @@ import org.apache.commons.imaging.icc.IccProfileParser;
  * at the main project development web site.
  * </p>
  *
- * <h4>Optional parameters for image reading and writing</h4>
+ * <h3>Optional parameters for image reading and writing</h3>
  *
  * <p>
  * Some of the methods provided by this class accept an optional
@@ -99,7 +99,7 @@ import org.apache.commons.imaging.icc.IccProfileParser;
  * JpegContants or TiffConstants.
  * </p>
  *
- * <h4>Example code</h4>
+ * <h3>Example code</h3>
  *
  * <p>
  * See the source of the SampleUsage class and other classes in the

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -424,7 +424,7 @@ public class TiffImageParser extends ImageParser {
      * supplying the appropriate parameters using the keys from the
      * TiffConstants class and the params argument for this method.</p>
      *
-     * <h3>Loading Partial Images</h3>
+     * <p><strong>Loading Partial Images</strong></p>
      *
      * <p>The TIFF parser includes support for loading partial images without
      * committing significantly more memory resources than are necessary


### PR DESCRIPTION
In my other PR #51 there was one failure in Travis due to Javadoc and headings out of order.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.0:javadoc (default-cli) on project commons-imaging: An error has occurred in Javadoc report generation: 

[ERROR] Exit code: 1 - /home/travis/build/apache/commons-imaging/src/main/java/org/apache/commons/imaging/Imaging.java:48: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>

[ERROR]  * <h3>Application Notes</h3>

[ERROR]    ^

[ERROR] /home/travis/build/apache/commons-imaging/src/main/java/org/apache/commons/imaging/ImageParser.java:63: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>

[ERROR]  * <h3>Application Notes</h3>

[ERROR]    ^

[ERROR] /home/travis/build/apache/commons-imaging/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java:427: error: unexpected heading used: <H3>, compared to implicit preceding heading: <H3>

[ERROR]      * <h3>Loading Partial Images</h3>

[ERROR]        ^

[ERROR] 

[ERROR] Command line was: /home/travis/openjdk13/bin/javadoc @options @packages

[ERROR] 

[ERROR] Refer to the generated Javadoc files in '/home/travis/build/apache/commons-imaging/target/site/apidocs' dir.

[ERROR] 

[ERROR] -> [Help 1]

[ERROR] 

[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.

[ERROR] Re-run Maven using the -X switch to enable full debug logging.

[ERROR] 

[ERROR] For more information about the errors and possible solutions, please read the following articles:

[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

The command "mvn" exited with 1.
```

This PR changes the heading orders, making `h1` the first. If this one passes, I will merge and then rebase my other PR.

Cheers
Bruno