### PR TITLE
Close OutputStream before toByteArray() on underlying ByteArrayOutputStream

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossy.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossy.java
@@ -50,6 +50,8 @@ public class TiffImageWriterLossy extends TiffImageWriterBase {
         final BinaryOutputStream bos = new BinaryOutputStream(os, byteOrder);
 
         writeStep(bos, outputItems);
+
+        bos.close();
     }
 
     private void updateOffsetsStep(final List<TiffOutputItem> outputItems) {


### PR DESCRIPTION
When an `OutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is [recommended](https://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java) to flush or close the `OutputStream` before invoking the underlying instances' `toByteArray()`.

This pull request adds a call to `close` at the end of the `write` method of `TiffImageWriterLossy`.