### PR TITLE
[IMAGING-163] Add XmpEmbedabble interface to parsers that support it

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2019-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-163" dev="kinow" type="fix">
+        Add XmpEmbedabble interface to parsers that support it
+      </action>
       <action issue="IMAGING-245" dev="kinow" type="add" due-to="Christoffer Rydberg">
         Add disposal method to GIF metadata
       </action>

--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -669,26 +669,6 @@ public abstract class ImageParser extends BinaryFileParser {
             throws ImageReadException, IOException;
 
     /**
-     * Get a string containing XML-formatted text conforming to the Extensible
-     * Metadata  Platform (EXP) standard for representing information about
-     * image content.  Not all image formats support EXP infomation and
-     * even for those that do, there is no guarantee that such information
-     * will be present in an image.
-     *
-     * @param byteSource A valid reference to a ByteSource.
-     * @param params     Optional instructions for special-handling or
-     *                   interpretation of the input data.
-     * @return If XMP metadata is present, a valid string;
-     *         if it is not present, a null.
-     * @throws ImageReadException In the event that the specified content
-     *                            does not conform to the format of the specific
-     *                            parser implementation.
-     * @throws IOException        In the event of unsuccessful read or access operation.
-     */
-    public abstract String getXmpXml(ByteSource byteSource, Map<String, Object> params)
-            throws ImageReadException, IOException;
-
-    /**
      * Get an array of bytes describing the International Color Consortium (ICC)
      * specification for the color space of the image contained in the
      * input byte array. Not all formats support ICC profiles.

--- a/src/main/java/org/apache/commons/imaging/Imaging.java
+++ b/src/main/java/org/apache/commons/imaging/Imaging.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
@@ -975,8 +976,10 @@ public final class Imaging {
     public static String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
             throws ImageReadException, IOException {
         final ImageParser imageParser = getImageParser(byteSource);
-
-        return imageParser.getXmpXml(byteSource, params);
+        if (imageParser instanceof XmpEmbeddable) {
+            return ((XmpEmbeddable) imageParser).getXmpXml(byteSource, params);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/apache/commons/imaging/common/XmpEmbeddable.java
+++ b/src/main/java/org/apache/commons/imaging/common/XmpEmbeddable.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.common;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.imaging.ImageReadException;
+import org.apache.commons.imaging.common.bytesource.ByteSource;
+
+/**
+ * Implementations support embedding the Extensible Metadata Platform
+ * tags.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Extensible_Metadata_Platform">https://en.wikipedia.org/wiki/Extensible_Metadata_Platform</a>
+ * @since 1.0
+ */
+public interface XmpEmbeddable {
+
+    /**
+     * Get a string containing XML-formatted text conforming to the Extensible
+     * Metadata  Platform (EXP) standard for representing information about
+     * image content.  Not all image formats support EXP infomation and
+     * even for those that do, there is no guarantee that such information
+     * will be present in an image.
+     *
+     * @param byteSource A valid reference to a ByteSource.
+     * @param params     Optional instructions for special-handling or
+     *                   interpretation of the input data.
+     * @return If XMP metadata is present, a valid string;
+     *         if it is not present, a null.
+     * @throws ImageReadException In the event that the specified content
+     *                            does not conform to the format of the specific
+     *                            parser implementation.
+     * @throws IOException        In the event of unsuccessful read or access operation.
+     */
+    String getXmpXml(ByteSource byteSource, Map<String, Object> params)
+            throws ImageReadException, IOException;
+
+}

--- a/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
@@ -759,21 +759,4 @@ public class BmpImageParser extends ImageParser {
         // write Image Data
         bos.write(imagedata);
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
-
 }

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -241,20 +241,4 @@ public class DcxImageParser extends ImageParser {
         final PcxImageParser pcxImageParser = new PcxImageParser();
         pcxImageParser.writeImage(src, bos, pcxParams);
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -51,13 +51,14 @@ import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.common.BinaryOutputStream;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.mylzw.MyLzwCompressor;
 import org.apache.commons.imaging.common.mylzw.MyLzwDecompressor;
 import org.apache.commons.imaging.palette.Palette;
 import org.apache.commons.imaging.palette.PaletteFactory;
 
-public class GifImageParser extends ImageParser {
+public class GifImageParser extends ImageParser implements XmpEmbeddable {
 
     private static final Logger LOGGER = Logger.getLogger(GifImageParser.class.getName());
 

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
@@ -328,20 +328,4 @@ public class IcnsImageParser extends ImageParser {
             }
         }
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
@@ -800,20 +800,4 @@ public class IcoImageParser extends ImageParser {
         }
         bos.close();
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -42,6 +42,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageParser;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.jpeg.decoder.JpegDecoder;
 import org.apache.commons.imaging.formats.jpeg.iptc.IptcParser;
@@ -63,7 +64,7 @@ import org.apache.commons.imaging.formats.tiff.TiffImageParser;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
 import org.apache.commons.imaging.internal.Debug;
 
-public class JpegImageParser extends ImageParser {
+public class JpegImageParser extends ImageParser implements XmpEmbeddable {
 
     private static final Logger LOGGER = Logger.getLogger(JpegImageParser.class.getName());
 

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -494,20 +494,4 @@ public class PcxImageParser extends ImageParser {
             throws ImageWriteException, IOException {
         new PcxWriter(params).writeImage(src, os);
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
@@ -51,6 +51,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.png.chunks.PngChunk;
 import org.apache.commons.imaging.formats.png.chunks.PngChunkGama;
@@ -70,7 +71,7 @@ import org.apache.commons.imaging.formats.png.transparencyfilters.TransparencyFi
 import org.apache.commons.imaging.formats.png.transparencyfilters.TransparencyFilterTrueColor;
 import org.apache.commons.imaging.icc.IccProfileParser;
 
-public class PngImageParser extends ImageParser {
+public class PngImageParser extends ImageParser  implements XmpEmbeddable {
 
     private static final Logger LOGGER = Logger.getLogger(PngImageParser.class.getName());
 

--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -374,20 +374,4 @@ public class PnmImageParser extends ImageParser {
 
         writer.writeImage(src, os, params);
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageParser.java
@@ -41,6 +41,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageParser;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.psd.dataparsers.DataParser;
 import org.apache.commons.imaging.formats.psd.dataparsers.DataParserBitmap;
@@ -53,7 +54,7 @@ import org.apache.commons.imaging.formats.psd.datareaders.CompressedDataReader;
 import org.apache.commons.imaging.formats.psd.datareaders.DataReader;
 import org.apache.commons.imaging.formats.psd.datareaders.UncompressedDataReader;
 
-public class PsdImageParser extends ImageParser {
+public class PsdImageParser extends ImageParser implements XmpEmbeddable {
     private static final String DEFAULT_EXTENSION = ".psd";
     private static final String[] ACCEPTED_EXTENSIONS = { DEFAULT_EXTENSION, };
     private static final int PSD_SECTION_HEADER = 0;

--- a/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
@@ -129,10 +129,4 @@ public class RgbeImageParser extends ImageParser {
             throws ImageReadException, IOException {
         return null;
     }
-
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -46,6 +46,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.tiff.TiffDirectory.ImageDataElement;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
@@ -62,7 +63,7 @@ import org.apache.commons.imaging.formats.tiff.photometricinterpreters.Photometr
 import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterYCbCr;
 import org.apache.commons.imaging.formats.tiff.write.TiffImageWriterLossy;
 
-public class TiffImageParser extends ImageParser {
+public class TiffImageParser extends ImageParser implements XmpEmbeddable {
     private static final String DEFAULT_EXTENSION = ".tif";
     private static final String[] ACCEPTED_EXTENSIONS = { ".tif", ".tiff", };
 

--- a/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
@@ -261,20 +261,4 @@ public class WbmpImageParser extends ImageParser {
             }
         }
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
@@ -410,20 +410,4 @@ public class XbmImageParser extends ImageParser {
 
         os.write("\n};\n".getBytes(StandardCharsets.US_ASCII));
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
@@ -731,20 +731,4 @@ public class XpmImageParser extends ImageParser {
         line = "\n};\n";
         os.write(line.getBytes(StandardCharsets.US_ASCII));
     }
-
-    /**
-     * Extracts embedded XML metadata as XML string.
-     * <p>
-     *
-     * @param byteSource
-     *            File containing image data.
-     * @param params
-     *            Map of optional parameters, defined in ImagingConstants.
-     * @return Xmp Xml as String, if present. Otherwise, returns null.
-     */
-    @Override
-    public String getXmpXml(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        return null;
-    }
 }


### PR DESCRIPTION
An alternative propose to IMAGING-163. See #9 for another approach.

In this PR, a new interface `XmpEmbeddable` is added. The `getXmpXml` method is removed from the `ImageParser`, and from any parser that was always returning `null`.

Now, instead, only the parsers that currently support XMP metadata tags implement that method. Not all parsers will implement this interface, as not all image format specifications support XMP.