### PR TITLE
[IMAGING-236] Add support to read multiple images from GIF

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageData.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageData.java
@@ -1,5 +1,3 @@
-package org.apache.commons.imaging.formats.gif;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +14,8 @@ package org.apache.commons.imaging.formats.gif;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.commons.imaging.formats.gif;
+
 class GifImageData {
     final ImageDescriptor descriptor;
     final GraphicControlExtension gce;

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageData.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageData.java
@@ -1,0 +1,27 @@
+package org.apache.commons.imaging.formats.gif;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class GifImageData {
+    final ImageDescriptor descriptor;
+    final GraphicControlExtension gce;
+
+    GifImageData(ImageDescriptor descriptor, GraphicControlExtension gce) {
+        this.descriptor = descriptor;
+        this.gce = gce;
+    }
+}

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadata.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.formats.gif;
+
+import org.apache.commons.imaging.common.ImageMetadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class GifImageMetadata implements ImageMetadata {
+    private static final String NEWLINE = System.getProperty("line.separator");
+    private final int width;
+    private final int height;
+    private final List<GifImageMetadataItem> items;
+
+    GifImageMetadata(int width, int height, List<GifImageMetadataItem> items) {
+        this.width = width;
+        this.height = height;
+        this.items = Collections.unmodifiableList(new ArrayList<>(items));
+    }
+
+    @Override
+    public String toString(String prefix) {
+        prefix = prefix == null ? "" : prefix;
+        final StringBuilder result = new StringBuilder();
+        result.append(String.format("%sGIF metadata:", prefix));
+        result.append(String.format("%sWidth: %d%s", prefix, width, NEWLINE));
+        result.append(String.format("%sHeight: %d%s", prefix, height, NEWLINE));
+        result.append(NEWLINE);
+        result.append(String.format("%sImages:", prefix));
+        for (GifImageMetadataItem item : items) {
+            result.append(NEWLINE);
+            result.append(item.toString(prefix));
+        }
+        return result.toString();
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    @Override
+    public List<GifImageMetadataItem> getItems() {
+        return items;
+    }
+}

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadata.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadata.java
@@ -22,22 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 public class GifImageMetadata implements ImageMetadata {
     private static final String NEWLINE = System.getProperty("line.separator");
     private final int width;

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadataItem.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadataItem.java
@@ -1,0 +1,54 @@
+package org.apache.commons.imaging.formats.gif;
+
+import org.apache.commons.imaging.common.ImageMetadata;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class GifImageMetadataItem implements ImageMetadata.ImageMetadataItem {
+    private static final String NEWLINE = System.getProperty("line.separator");
+    private final int delay;
+    private final int leftPosition;
+    private final int topPosition;
+
+    GifImageMetadataItem(int delay, int leftPosition, int topPosition) {
+        this.delay = delay;
+        this.leftPosition = leftPosition;
+        this.topPosition = topPosition;
+    }
+
+    public int getDelay() {
+        return delay;
+    }
+
+    public int getLeftPosition() {
+        return leftPosition;
+    }
+
+    public int getTopPosition() {
+        return topPosition;
+    }
+
+    @Override
+    public String toString(String prefix) {
+        prefix = prefix == null ? "" : prefix;
+        final StringBuilder result = new StringBuilder();
+        result.append(String.format("%sDelay: %d%s", prefix, delay, NEWLINE));
+        result.append(String.format("%sLeft position: %d%s", prefix, leftPosition, NEWLINE));
+        result.append(String.format("%sTop position: %d%s", prefix, topPosition, NEWLINE));
+        return result.toString();
+    }
+}

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadataItem.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageMetadataItem.java
@@ -1,7 +1,3 @@
-package org.apache.commons.imaging.formats.gif;
-
-import org.apache.commons.imaging.common.ImageMetadata;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +14,10 @@ import org.apache.commons.imaging.common.ImageMetadata;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.commons.imaging.formats.gif;
+
+import org.apache.commons.imaging.common.ImageMetadata;
+
 public class GifImageMetadataItem implements ImageMetadata.ImageMetadataItem {
     private static final String NEWLINE = System.getProperty("line.separator");
     private final int delay;

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -439,6 +439,11 @@ public class GifImageParser extends ImageParser {
         return null;
     }
 
+    /**
+     * See {@link GifImageParser#readBlocks} for reference how the blocks are created. They should match
+     * the code we are giving here, returning the correct class type. Internal only.
+     */
+    @SuppressWarnings("unchecked")
     private <T extends GifBlock> List<T> findAllBlocks(final List<GifBlock> blocks, final int code) {
         final List<T> filteredBlocks = new ArrayList<>();
         for (final GifBlock gifBlock : blocks) {

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -25,7 +25,7 @@ import static org.apache.commons.imaging.common.BinaryFunctions.read2Bytes;
 import static org.apache.commons.imaging.common.BinaryFunctions.readByte;
 import static org.apache.commons.imaging.common.BinaryFunctions.readBytes;
 
-import java.awt.Dimension;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -439,6 +439,16 @@ public class GifImageParser extends ImageParser {
         return null;
     }
 
+    private <T extends GifBlock> List<T> findAllBlocks(final List<GifBlock> blocks, final int code) {
+        final List<T> filteredBlocks = new ArrayList<>();
+        for (final GifBlock gifBlock : blocks) {
+            if (gifBlock.blockCode == code) {
+                filteredBlocks.add((T) gifBlock);
+            }
+        }
+        return filteredBlocks;
+    }
+
     private GifImageContents readFile(final ByteSource byteSource,
             final boolean stopBeforeImageData) throws ImageReadException, IOException {
         return readFile(byteSource, stopBeforeImageData,
@@ -492,17 +502,29 @@ public class GifImageParser extends ImageParser {
             throw new ImageReadException("GIF: Couldn't read ImageDescriptor");
         }
 
-        // Prefer the size information in the ImageDescriptor; it is more
-        // reliable
-        // than the size information in the header.
-        return new Dimension(id.imageWidth, id.imageHeight);
+        return new Dimension(bhi.logicalScreenWidth, bhi.logicalScreenHeight);
     }
 
-    // FIXME should throw UOE
     @Override
     public ImageMetadata getMetadata(final ByteSource byteSource, final Map<String, Object> params)
             throws ImageReadException, IOException {
-        return null;
+        final GifImageContents imageContents = readFile(byteSource, false);
+
+        if (imageContents == null) {
+            throw new ImageReadException("GIF: Couldn't read blocks");
+        }
+
+        final GifHeaderInfo bhi = imageContents.gifHeaderInfo;
+        if (bhi == null) {
+            throw new ImageReadException("GIF: Couldn't read Header");
+        }
+
+        final List<GifImageData> imageData = findAllImageData(imageContents);
+        List<GifImageMetadataItem> metadataItems = new ArrayList<>(imageData.size());
+        for(GifImageData id : imageData) {
+            metadataItems.add(new GifImageMetadataItem(id.gce.delay, id.descriptor.imageLeftPosition, id.descriptor.imageTopPosition));
+        }
+        return new GifImageMetadata(bhi.logicalScreenWidth, bhi.logicalScreenHeight, metadataItems);
     }
 
     private List<String> getComments(final List<GifBlock> blocks) throws IOException {
@@ -542,18 +564,16 @@ public class GifImageParser extends ImageParser {
         final GraphicControlExtension gce = (GraphicControlExtension) findBlock(
                 blocks.blocks, GRAPHIC_CONTROL_EXTENSION);
 
-        // Prefer the size information in the ImageDescriptor; it is more
-        // reliable than the size information in the header.
-        final int height = id.imageHeight;
-        final int width = id.imageWidth;
+        final int height = bhi.logicalScreenHeight;
+        final int width = bhi.logicalScreenWidth;
 
         final List<String> comments = getComments(blocks.blocks);
         final int bitsPerPixel = (bhi.colorResolution + 1);
         final ImageFormat format = ImageFormats.GIF;
         final String formatName = "GIF Graphics Interchange Format";
         final String mimeType = "image/gif";
-        // we ought to count images, but don't yet.
-        final int numberOfImages = -1;
+
+        final int numberOfImages = findAllBlocks(blocks.blocks, IMAGE_SEPARATOR).size();
 
         final boolean progressive = id.interlaceFlag;
 
@@ -643,31 +663,53 @@ public class GifImageParser extends ImageParser {
         return result;
     }
 
-    @Override
-    public BufferedImage getBufferedImage(final ByteSource byteSource, final Map<String, Object> params)
-            throws ImageReadException, IOException {
-        final GifImageContents imageContents = readFile(byteSource, false);
+    private List<GifImageData> findAllImageData(GifImageContents imageContents) throws ImageReadException {
+        final List<ImageDescriptor> descriptors = findAllBlocks(imageContents.blocks, IMAGE_SEPARATOR);
 
-        if (imageContents == null) {
-            throw new ImageReadException("GIF: Couldn't read blocks");
-        }
-
-        final GifHeaderInfo ghi = imageContents.gifHeaderInfo;
-        if (ghi == null) {
-            throw new ImageReadException("GIF: Couldn't read Header");
-        }
-
-        final ImageDescriptor id = (ImageDescriptor) findBlock(imageContents.blocks,
-                IMAGE_SEPARATOR);
-        if (id == null) {
+        if (descriptors.size() == 0) {
             throw new ImageReadException("GIF: Couldn't read Image Descriptor");
         }
+
+        final List<GraphicControlExtension> gcExtensions = findAllBlocks(imageContents.blocks, GRAPHIC_CONTROL_EXTENSION);
+
+        if (gcExtensions.size() != 0 && gcExtensions.size() != descriptors.size()) {
+            throw new ImageReadException("GIF: Invalid amount of Graphic Control Extensions");
+        }
+
+        List<GifImageData> imageData = new ArrayList<>(descriptors.size());
+        for(int i = 0; i < descriptors.size(); i++) {
+            final ImageDescriptor descriptor = descriptors.get(i);
+            if (descriptor == null) {
+                throw new ImageReadException(String.format("GIF: Couldn't read Image Descriptor of image number %d", i));
+            }
+
+            final GraphicControlExtension gce = gcExtensions.size() == 0 ? null : gcExtensions.get(i);
+
+            imageData.add(new GifImageData(descriptor, gce));
+        }
+
+        return imageData;
+    }
+
+    private GifImageData findFirstImageData(GifImageContents imageContents) throws ImageReadException {
+        final ImageDescriptor descriptor = (ImageDescriptor) findBlock(imageContents.blocks,
+                IMAGE_SEPARATOR);
+
+        if (descriptor == null) {
+            throw new ImageReadException("GIF: Couldn't read Image Descriptor");
+        }
+
         final GraphicControlExtension gce = (GraphicControlExtension) findBlock(
                 imageContents.blocks, GRAPHIC_CONTROL_EXTENSION);
 
-        // Prefer the size information in the ImageDescriptor; it is more
-        // reliable
-        // than the size information in the header.
+        return new GifImageData(descriptor, gce);
+    }
+
+    private final BufferedImage getBufferedImage(GifHeaderInfo headerInfo, GifImageData imageData, byte[] globalColorTable)
+            throws ImageReadException {
+        final ImageDescriptor id = imageData.descriptor;
+        final GraphicControlExtension gce = imageData.gce;
+
         final int width = id.imageWidth;
         final int height = id.imageHeight;
 
@@ -681,8 +723,8 @@ public class GifImageParser extends ImageParser {
         int[] colorTable;
         if (id.localColorTable != null) {
             colorTable = getColorTable(id.localColorTable);
-        } else if (imageContents.globalColorTable != null) {
-            colorTable = getColorTable(imageContents.globalColorTable);
+        } else if (globalColorTable != null) {
+            colorTable = getColorTable(globalColorTable);
         } else {
             throw new ImageReadException("Gif: No Color Table");
         }
@@ -734,14 +776,52 @@ public class GifImageParser extends ImageParser {
                 if (transparentIndex == index) {
                     rgb = 0x00;
                 }
-
-                imageBuilder.setRGB(x, y, rgb);
+                imageBuilder.setRGB(x,y, rgb);
             }
-
         }
 
         return imageBuilder.getBufferedImage();
+    }
 
+    @Override
+    public List<BufferedImage> getAllBufferedImages(final ByteSource byteSource)
+            throws ImageReadException, IOException {
+        final GifImageContents imageContents = readFile(byteSource, false);
+
+        if (imageContents == null) {
+            throw new ImageReadException("GIF: Couldn't read blocks");
+        }
+
+        final GifHeaderInfo ghi = imageContents.gifHeaderInfo;
+        if (ghi == null) {
+            throw new ImageReadException("GIF: Couldn't read Header");
+        }
+
+        final List<GifImageData> imageData = findAllImageData(imageContents);
+        List<BufferedImage> result = new ArrayList<>(imageData.size());
+        for(GifImageData id : imageData) {
+            result.add(getBufferedImage(ghi, id, imageContents.globalColorTable));
+        }
+        return result;
+    }
+
+    @Override
+    public BufferedImage getBufferedImage(final ByteSource byteSource, final Map<String, Object> params)
+            throws ImageReadException, IOException {
+        final GifImageContents imageContents = readFile(byteSource, false);
+
+        if (imageContents == null) {
+            throw new ImageReadException("GIF: Couldn't read blocks");
+        }
+
+        final GifHeaderInfo ghi = imageContents.gifHeaderInfo;
+        if (ghi == null) {
+            throw new ImageReadException("GIF: Couldn't read Header");
+        }
+
+        final GifImageData imageData = findFirstImageData(imageContents);
+
+        return getBufferedImage(ghi, imageData, imageContents.globalColorTable);
     }
 
     private void writeAsSubBlocks(final OutputStream os, final byte[] bytes) throws IOException {

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -495,7 +495,7 @@ public class GifImageParser extends ImageParser {
         if (bhi == null) {
             throw new ImageReadException("GIF: Couldn't read Header");
         }
-        
+
         // The logical screen width and height defines the overall dimensions of the image
         // space from the top left corner. This does not necessarily match the dimensions
         // of any individual image, or even the dimensions created by overlapping all

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -25,7 +25,7 @@ import static org.apache.commons.imaging.common.BinaryFunctions.read2Bytes;
 import static org.apache.commons.imaging.common.BinaryFunctions.readByte;
 import static org.apache.commons.imaging.common.BinaryFunctions.readBytes;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -495,13 +495,12 @@ public class GifImageParser extends ImageParser {
         if (bhi == null) {
             throw new ImageReadException("GIF: Couldn't read Header");
         }
-
-        final ImageDescriptor id = (ImageDescriptor) findBlock(blocks.blocks,
-                IMAGE_SEPARATOR);
-        if (id == null) {
-            throw new ImageReadException("GIF: Couldn't read ImageDescriptor");
-        }
-
+        
+        // The logical screen width and height defines the overall dimensions of the image
+        // space from the top left corner. This does not necessarily match the dimensions
+        // of any individual image, or even the dimensions created by overlapping all
+        // images (since each images might have an offset from the top left corner).
+        // Nevertheless, these fields indicate the desired screen dimensions when rendering the GIF.
         return new Dimension(bhi.logicalScreenWidth, bhi.logicalScreenHeight);
     }
 
@@ -705,7 +704,7 @@ public class GifImageParser extends ImageParser {
         return new GifImageData(descriptor, gce);
     }
 
-    private final BufferedImage getBufferedImage(GifHeaderInfo headerInfo, GifImageData imageData, byte[] globalColorTable)
+    private BufferedImage getBufferedImage(GifHeaderInfo headerInfo, GifImageData imageData, byte[] globalColorTable)
             throws ImageReadException {
         final ImageDescriptor id = imageData.descriptor;
         final GraphicControlExtension gce = imageData.gce;

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -59,6 +59,29 @@ public class GifReadTest extends GifBaseTest {
     }
 
     @Test
+    public void testImageDimensions() throws Exception {
+        final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
+        final GifImageMetadata metadata = (GifImageMetadata) Imaging.getMetadata(imageFile);
+        final List<BufferedImage> images = Imaging.getAllBufferedImages(imageFile);
+
+        int width = 0;
+        int height = 0;
+        for(int i = 0; i < images.size(); i++) {
+            final BufferedImage image = images.get(i);
+            final GifImageMetadataItem metadataItem = metadata.getItems().get(i);
+            final int xOffset = metadataItem.getLeftPosition();
+            final int yOffset = metadataItem.getTopPosition();
+            width = Math.max(width, image.getWidth() + xOffset);
+            height = Math.max(height, image.getHeight() + yOffset);
+        }
+
+        assertEquals(width, metadata.getWidth());
+        assertEquals(height, metadata.getHeight());
+        assertEquals(width, imageInfo.getWidth());
+        assertEquals(height, imageInfo.getHeight());
+    }
+
+    @Test
     public void testBufferedImage() throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -17,11 +17,10 @@
 
 package org.apache.commons.imaging.formats.gif;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
@@ -29,6 +28,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class GifReadTest extends GifBaseTest {
@@ -61,6 +62,13 @@ public class GifReadTest extends GifBaseTest {
     public void testBufferedImage() throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
+        // TODO assert more
+    }
+
+    @Test
+    public void testBufferedImages() throws Exception {
+        final List<BufferedImage> images = Imaging.getAllBufferedImages(imageFile);
+        assertTrue(images.size() > 0);
         // TODO assert more
     }
 }


### PR DESCRIPTION
This PR adds support to read more than one image from a GIF file. It also allows reading of metadata needed for visualization (such as the offset for each image). I did not yet create a jira account but will do so for any future pull requests. I quickly dug into code as I got frustrated with an old [bug](https://stackoverflow.com/questions/22259714/arrayindexoutofboundsexception-4096-while-reading-gif-file) in ImageIO. I hope you'll accept my PR or let me know what to change to meet the code standard.