### PR TITLE
IMAGING-238: Return copied byte arrays in PNG Chunk and ICCP PNG Chunk

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2019-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-238" dev="kinow" type="fix">
+        Return copied byte arrays in Png Chunk and Png Chunk ICCP
+      </action>
       <action issue="IMAGING-164" dev="kinow" type="add" due-to="Michael Groß">
         Simplify code in IcoImageParser::writeImage
       </action>

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunk.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunk.java
@@ -36,7 +36,7 @@ public class PngChunk extends BinaryFileParser {
         this.length = length;
         this.chunkType = chunkType;
         this.crc = crc;
-        this.bytes = bytes; // TODO clone?
+        this.bytes = bytes.clone();
 
         propertyBits = new boolean[4];
         int shift = 24;
@@ -54,7 +54,7 @@ public class PngChunk extends BinaryFileParser {
     }
 
     public byte[] getBytes() {
-        return bytes; // TODO clone?
+        return bytes.clone();
     }
 
     public boolean[] getPropertyBits() {

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunk.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunk.java
@@ -20,6 +20,12 @@ import java.io.ByteArrayInputStream;
 
 import org.apache.commons.imaging.common.BinaryFileParser;
 
+/**
+ * A PNG image is composed of several chunks. This is the base class for the chunks,
+ * used by the parser.
+ *
+ * @see https://en.wikipedia.org/wiki/Portable_Network_Graphics#%22Chunks%22_within_the_file
+ */
 public class PngChunk extends BinaryFileParser {
     public final int length;
     public final int chunkType;
@@ -32,6 +38,13 @@ public class PngChunk extends BinaryFileParser {
     public final boolean reserved;
     public final boolean safeToCopy;
 
+    /**
+     * Constructor.
+     * @param length chunk length
+     * @param chunkType chunk type
+     * @param crc CRC computed over the chunk type and chunk data (but not the length)
+     * @param bytes chunk data bytes
+     */
     public PngChunk(final int length, final int chunkType, final int crc, final byte[] bytes) {
         this.length = length;
         this.chunkType = chunkType;
@@ -53,14 +66,29 @@ public class PngChunk extends BinaryFileParser {
         safeToCopy = propertyBits[3];
     }
 
+    /**
+     * Return a copy of the chunk bytes.
+     * @return the chunk bytes
+     */
     public byte[] getBytes() {
         return bytes.clone();
     }
 
+    /**
+     * Return a copy of the chunk property bits.
+     * @return the chunk property bits
+     */
     public boolean[] getPropertyBits() {
         return propertyBits.clone();
     }
 
+    /**
+     * Create and return a {@link ByteArrayInputStream} for the chunk bytes.
+     *
+     * <p>The caller is responsible for closing the resource.</p>
+     *
+     * @return a ByteArrayInputStream for the chunk bytes
+     */
     protected ByteArrayInputStream getDataStream() {
         return new ByteArrayInputStream(getBytes());
     }

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
@@ -39,7 +39,7 @@ public class PngChunkIccp extends PngChunk {
     private final byte[] uncompressedProfile;
 
     public byte[] getUncompressedProfile() {
-        return uncompressedProfile; // TODO clone?
+        return uncompressedProfile.clone();
     }
 
     public PngChunkIccp(

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
@@ -28,26 +28,49 @@ import java.util.zip.InflaterInputStream;
 
 import org.apache.commons.imaging.ImageReadException;
 
+/**
+ * The PNG iCCP chunk. If "present, the image samples conform to the color space represented by the embedded ICC
+ * profile as defined by the International Color Consortium".
+ *
+ * @see http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html
+ */
 public class PngChunkIccp extends PngChunk {
 
+    /*
+     * Logger.
+     */
     private static final Logger LOGGER = Logger.getLogger(PngChunkIccp.class.getName());
 
-    // private final PngImageParser parser;
+    /**
+     * ICC profile name.
+     */
     public final String profileName;
+    /**
+     * Compression method.
+     */
     public final int compressionMethod;
+    /**
+     * Compressed profile data.
+     */
     private final byte[] compressedProfile;
+    /**
+     * Uncompressed profile data.
+     */
     private final byte[] uncompressedProfile;
 
-    public byte[] getUncompressedProfile() {
-        return uncompressedProfile.clone();
-    }
-
+    /**
+     * Constructor.
+     * @param length chunk length
+     * @param chunkType chunk type
+     * @param crc CRC computed over the chunk type and chunk data (but not the length)
+     * @param bytes chunk data bytes
+     * @throws ImageReadException when no profile name is present
+     * @throws IOException when an error happens while reading the profile data
+     */
     public PngChunkIccp(
-    // PngImageParser parser,
             final int length, final int chunkType, final int crc, final byte[] bytes)
             throws ImageReadException, IOException {
         super(length, chunkType, crc, bytes);
-        // this.parser = parser;
 
         final int index = findNull(bytes);
         if (index < 0) {
@@ -76,6 +99,14 @@ public class PngChunkIccp extends PngChunk {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.finest("UncompressedProfile: " + Integer.toString(bytes.length));
         }
+    }
+
+    /**
+     * Return a copy of the uncompressed profile data.
+     * @return the uncompressed profile data
+     */
+    public byte[] getUncompressedProfile() {
+        return uncompressedProfile.clone();
     }
 
 }

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkPlte.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkPlte.java
@@ -54,7 +54,7 @@ public class PngChunkPlte extends PngChunk {
     }
 
     public int[] getRgb() {
-        return rgb; // TODO clone? Is the method used?
+        return rgb.clone();
     }
 
     public int getRGB(final int index) throws ImageReadException {

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.formats.png.chunks;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+import org.apache.commons.imaging.ImageReadException;
+import org.junit.Test;
+
+/**
+ * Tests for {@link PngChunkIccp}.
+ */
+public class PngChunkIccpTest {
+
+    private static final int chunkType = 1766015824;
+
+    @Test(expected = ImageReadException.class)
+    public void testErrorOnNoProfileName() throws ImageReadException, IOException {
+        final byte[] data = new byte[0];
+        new PngChunkIccp(0, chunkType, 0, data);
+    }
+
+    @Test
+    public void testParsingIccpChunk() throws ImageReadException, IOException {
+        final List<Byte> bytes = new ArrayList<>();
+        final String profileName = "my-profile-01";
+        for (byte b : profileName.getBytes(StandardCharsets.ISO_8859_1)) {
+            bytes.add(new Byte(b));
+        }
+        bytes.add(new Byte((byte) 0)); // null
+        bytes.add(new Byte((byte) 0)); // 0=deflate compression method
+        
+        // generate some 100 bytes of dummy data
+        byte[] uncompressedData = new byte[100];
+        IntStream.range(0, 100).forEach((i) -> {
+            uncompressedData[i] = (byte) (i + 1); // dummy data
+        });
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(100)) {
+            // compress the dummy data with deflate
+            Deflater def = new Deflater();
+            try (DeflaterOutputStream ios = new DeflaterOutputStream(baos, def)) {
+                ios.write(uncompressedData);
+            }
+            baos.flush();
+            byte[] compressedData = baos.toByteArray();
+            final byte[] data = new byte[bytes.size() + compressedData.length];
+            // gather everything, except for the compressed data
+            for (int i = 0; i < bytes.size(); ++i) {
+                data[i] = bytes.get(i).byteValue();
+            }
+            // gather the compressed data
+            IntStream.range(0, compressedData.length).forEach((i) -> {
+                data[bytes.size() + i] = compressedData[i];
+            });
+            // create the chunk
+            final PngChunkIccp chunk = new PngChunkIccp(data.length, chunkType, 0, data);
+            assertArrayEquals(uncompressedData, chunk.getUncompressedProfile());
+        }
+    }
+}


### PR DESCRIPTION
Returns copied byte arrays, adds javadocs, and also adds a unit test for the ICCP chunk.