### PR TITLE
[IMAGING-242] Upgrade to Junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@
       <version>2.1</version>
       <scope>test</scope>
     </dependency>
+    <!-- the next three dependencies are for tests with theories/datapoints, see IMAGING-242 -->
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <commons.distSvnStagingUrl>scm:svn:https://dist.apache.org/repos/dist/dev/commons/imaging</commons.distSvnStagingUrl>
     <commons.releaseManagerName>Bruno P. Kinoshita</commons.releaseManagerName>
     <commons.releaseManagerKey>33C6E01240C5468C2B7A556954E2764B48A42DF0</commons.releaseManagerKey>
+    <junit.version>5.5.2</junit.version>
   </properties>
 
   <scm>
@@ -213,9 +214,33 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2019-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-242" dev="kinow" type="fix">
+        Upgrade to JUnit 5
+      </action>
       <action issue="IMAGING-241" dev="kinow" type="fix">
         Copy byte arrays fixing TODO markers
       </action>

--- a/src/test/java/org/apache/commons/imaging/ImageDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImageDumpTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImageDumpTest {
 

--- a/src/test/java/org/apache/commons/imaging/ImagingGuessFormatTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImagingGuessFormatTest.java
@@ -17,18 +17,16 @@
 
 package org.apache.commons.imaging;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ImagingGuessFormatTest extends ImagingTest {
 
     public static final String BMP_IMAGE_FILE = "bmp\\1\\Oregon Scientific DS6639 - DSC_0307 - small.bmp";
@@ -45,11 +43,7 @@ public class ImagingGuessFormatTest extends ImagingTest {
     public static final String TGA_IMAGE_FILE = "tga\\1\\Oregon Scientific DS6639 - DSC_0307 - small.tga";
     public static final String UNKNOWN_IMAGE_FILE = "info.txt";
 
-    private final ImageFormats expectedFormat;
-    private final String pathToFile;
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
+    public static Stream<Object[]> data() {
         return Arrays.asList(
                 new Object[] { ImageFormats.PNG, PNG_IMAGE_FILE },
                 new Object[] { ImageFormats.GIF, GIF_IMAGE_FILE },
@@ -69,16 +63,12 @@ public class ImagingGuessFormatTest extends ImagingTest {
                 // new Object[] { ImageFormat.IMAGE_FORMAT_PNM, PNM_IMAGE_FILE },
                 // new Object[] { ImageFormat.IMAGE_FORMAT_JBIG2, JBIG2_IMAGE_FILE },
                 new Object[] { ImageFormats.UNKNOWN, UNKNOWN_IMAGE_FILE }
-        );
+        ).stream();
     }
 
-    public ImagingGuessFormatTest(final ImageFormats expectedFormat, final String pathToFile) {
-        this.expectedFormat = expectedFormat;
-        this.pathToFile = pathToFile;
-    }
-
-    @Test
-    public void testGuessFormat() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testGuessFormat(ImageFormats expectedFormat, String pathToFile) throws Exception {
         final String imagePath = FilenameUtils.separatorsToSystem(pathToFile);
         final File imageFile = new File(ImagingTestConstants.TEST_IMAGE_FOLDER, imagePath);
 

--- a/src/test/java/org/apache/commons/imaging/ImagingTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImagingTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,17 +26,16 @@ import java.util.List;
 
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.imaging.test.util.FileSystemTraversal;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class ImagingTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public File folder;
 
     protected File createTempFile(final String prefix, final String suffix)
             throws IOException {
-        return File.createTempFile(prefix, suffix, folder.newFolder());
+        return File.createTempFile(prefix, suffix, folder);
     }
 
     protected boolean isPhilHarveyTestImage(final File file) {

--- a/src/test/java/org/apache/commons/imaging/color/ColorCieLabTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorCieLabTest.java
@@ -16,20 +16,20 @@
  */
 package org.apache.commons.imaging.color;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ColorCieLabTest {
 
     private ColorCieLab color;
     private ColorCieLab colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorCieLab(1.0, 2.0, 3.0);
         colorCopy = new ColorCieLab(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorCieLchTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorCieLchTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorCieLchTest {
 
     private ColorCieLch color;
     private ColorCieLch colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorCieLch(1.0, 2.0, 3.0);
         colorCopy = new ColorCieLch(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorCieLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorCieLuvTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorCieLuvTest {
 
     private ColorCieLuv color;
     private ColorCieLuv colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorCieLuv(1.0, 2.0, 3.0);
         colorCopy = new ColorCieLuv(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorCmyTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorCmyTest.java
@@ -18,19 +18,19 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorCmyTest {
 
     private ColorCmy color;
     private ColorCmy colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorCmy(1.0, 2.0, 3.0);
         colorCopy = new ColorCmy(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorCmykTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorCmykTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorCmykTest {
 
     private ColorCmyk color;
     private ColorCmyk colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorCmyk(1.0, 2.0, 3.0, 4.0);
         colorCopy = new ColorCmyk(1.0, 2.0, 3.0, 4.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorConversionsTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorConversionsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.imaging.color;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColorConversionsTest {
     private static final int SAMPLE_RGBS[] = { 0xffffffff, 0xff000000,

--- a/src/test/java/org/apache/commons/imaging/color/ColorHslTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorHslTest.java
@@ -18,19 +18,19 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorHslTest {
 
     private ColorHsl color;
     private ColorHsl colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorHsl(1.0, 2.0, 3.0);
         colorCopy = new ColorHsl(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorHsvTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorHsvTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorHsvTest {
 
     private ColorHsv color;
     private ColorHsv colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorHsv(1.0, 2.0, 3.0);
         colorCopy = new ColorHsv(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorHunterLabTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorHunterLabTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorHunterLabTest {
 
     private ColorHunterLab color;
     private ColorHunterLab colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorHunterLab(1.0, 2.0, 3.0);
         colorCopy = new ColorHunterLab(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/color/ColorXyzTest.java
+++ b/src/test/java/org/apache/commons/imaging/color/ColorXyzTest.java
@@ -18,18 +18,18 @@ package org.apache.commons.imaging.color;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ColorXyzTest {
 
     private ColorXyz color;
     private ColorXyz colorCopy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         color = new ColorXyz(1.0, 2.0, 3.0);
         colorCopy = new ColorXyz(1.0, 2.0, 3.0);

--- a/src/test/java/org/apache/commons/imaging/common/BinaryFileFunctionsTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/BinaryFileFunctionsTest.java
@@ -15,12 +15,12 @@
 
 package org.apache.commons.imaging.common;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImagingTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BinaryFileFunctionsTest extends ImagingTest {
 

--- a/src/test/java/org/apache/commons/imaging/common/RationalNumberTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/RationalNumberTest.java
@@ -19,21 +19,16 @@ package org.apache.commons.imaging.common;
 
 import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class RationalNumberTest extends ImagingTest {
 
-    private final double testValue;
-
-    @Parameterized.Parameters
-    public static Collection<Double> data() {
+    public static Stream<Double> data() {
         return Arrays.<Double> asList(
                 0d, //
                 0.1d, //
@@ -105,15 +100,12 @@ public class RationalNumberTest extends ImagingTest {
                 (double) -(Long.MAX_VALUE), //
                 -(Long.MAX_VALUE + 0.1), //
                 -(Long.MAX_VALUE - 0.1) //
-        );
+        ).stream();
     }
 
-    public RationalNumberTest(final double testValue) {
-        this.testValue = testValue;
-    }
-
-    @Test
-    public void testRationalNumber() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRationalNumber(double testValue) {
         final RationalNumber rational = RationalNumber.valueOf(testValue);
         final double difference = Math.abs(testValue - rational.doubleValue());
 

--- a/src/test/java/org/apache/commons/imaging/common/RgbBufferedImageFactoryTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/RgbBufferedImageFactoryTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.DirectColorModel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RgbBufferedImageFactoryTest{
 

--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceDataTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceDataTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.common.bytesource;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -26,25 +26,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ByteSourceDataTest extends ByteSourceTest {
 
-    private final byte[] testByteArray;
-
-    @Parameterized.Parameters
-    public static Collection<byte[]> data() {
-        return Arrays.asList(getTestByteArrays());
-    }
-
-    public ByteSourceDataTest(final byte[] testByteArray) {
-        this.testByteArray = testByteArray;
+    public static Stream<byte[]> data() {
+        return Arrays.asList(getTestByteArrays()).stream();
     }
 
     private interface ByteSourceFactory {
@@ -134,16 +125,19 @@ public class ByteSourceDataTest extends ByteSourceTest {
 
     }
 
-    @Test
-    public void testByteSourceFileFactory() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testByteSourceFileFactory(byte[] testByteArray) throws Exception {
         writeAndReadBytes(new ByteSourceFileFactory(), testByteArray);
     }
-    @Test
-    public void testByteSourceInputStreamFileFactory() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testByteSourceInputStreamFileFactory(byte[] testByteArray) throws Exception {
         writeAndReadBytes(new ByteSourceInputStreamFileFactory(), testByteArray);
     }
-    @Test
-    public void testByteSourceInputStreamRawFactory() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testByteSourceInputStreamRawFactory(byte[] testByteArray) throws Exception {
         writeAndReadBytes(new ByteSourceInputStreamRawFactory(), testByteArray);
     }
 }

--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceImageTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceImageTest.java
@@ -17,20 +17,20 @@
 
 package org.apache.commons.imaging.common.bytesource;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageFormat;
 import org.apache.commons.imaging.ImageFormats;
@@ -40,26 +40,18 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ByteSourceImageTest extends ByteSourceTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getTestImages();
+    public static Stream<File> data() throws Exception {
+        return getTestImages().stream();
     }
 
-    public ByteSourceImageTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(File imageFile) throws Exception {
         Debug.debug("imageFile", imageFile);
         assertNotNull(imageFile);
 

--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
@@ -17,11 +17,12 @@
 package org.apache.commons.imaging.common.bytesource;
 
 import org.apache.commons.imaging.ImagingTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ByteSourceTest extends ImagingTest {
     protected File createTempFile(final byte src[]) throws IOException {
@@ -64,11 +65,13 @@ public abstract class ByteSourceTest extends ImagingTest {
         return new byte[][]{emptyArray, single, simple, zeroes, longArray,};
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetInputStreamThrowsNullPointerException() throws IOException {
         final ByteSourceArray byteSourceArray = new ByteSourceArray(null);
 
-        byteSourceArray.getInputStream(0L);
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            byteSourceArray.getInputStream(0L);
+        });
     }
 
 }

--- a/src/test/java/org/apache/commons/imaging/common/itu_t4/HuffmanTreeExceptionTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/itu_t4/HuffmanTreeExceptionTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.common.itu_t4;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class HuffmanTreeExceptionTest{
 

--- a/src/test/java/org/apache/commons/imaging/common/itu_t4/T4_T6_TablesTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/itu_t4/T4_T6_TablesTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.imaging.common.itu_t4;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class T4_T6_TablesTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -30,41 +30,39 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingTestConstants;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class BmpReadTest extends BmpBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
     public static Collection<File> data() throws Exception {
         return getBmpImages();
     }
 
-    public BmpReadTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void testImageInfo() throws ImageReadException, IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageInfo(File imageFile) throws ImageReadException, IOException {
         final Map<String, Object> params = Collections.emptyMap();
         final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);
         assertNotNull(imageInfo);
         // TODO assert more
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testMetaData() throws ImageReadException, IOException {
-        Imaging.getMetadata(imageFile);
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetaData(File imageFile) throws ImageReadException, IOException {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getMetadata(imageFile); 
+        });
     }
 
-    @Test
-    public void testBufferedImage() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImage(File imageFile) throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
         // TODO assert more
@@ -77,7 +75,7 @@ public class BmpReadTest extends BmpBaseTest {
      * @throws IOException
      * @throws ImageReadException
      */
-    @Test(timeout = 1000)
+    @Test
     public void testGetMaskShiftZeroMask() throws ImageReadException, IOException {
         File inputFile = new File(ImagingTestConstants.TEST_IMAGE_FOLDER +
                 "/bmp/5/@broken/timeout-bd15dbfa26b4e88070de540c6603039e8a88626f");

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.bmp;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -33,7 +33,7 @@ import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BmpRoundtripTest extends BmpBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpWriterRgbTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpWriterRgbTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BmpWriterRgbTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/dcx/DcxReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/dcx/DcxReadTest.java
@@ -17,47 +17,44 @@
 
 package org.apache.commons.imaging.formats.dcx;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class DcxReadTest extends DcxBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getDcxImages();
+    public static Stream<File> data() throws Exception {
+        return getDcxImages().stream();
     }
 
-    public DcxReadTest(final File imageFile) {
-        this.imageFile = imageFile;
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageMetadata(File imageFile) throws Exception {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getMetadata(imageFile);
+        });
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testImageMetadata() throws Exception {
-        Imaging.getMetadata(imageFile);
-    }
-
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testImageInfo() throws Exception {
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageInfo(File imageFile) throws Exception {
         Imaging.getImageInfo(imageFile, Collections.<String, Object> emptyMap());
     }
 
-    @Test
-    public void testBufferedImage() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImage(File imageFile) throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
         // TODO assert more

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -17,49 +17,48 @@
 
 package org.apache.commons.imaging.formats.gif;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.*;
-
-@RunWith(Parameterized.class)
 public class GifReadTest extends GifBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getGifImages();
+    public static Stream<File> data() throws Exception {
+        return getGifImages().stream();
     }
 
-    public GifReadTest(final File imageFile) {
-        this.imageFile = imageFile;
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetadata(File imageFile) throws Exception {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getMetadata(imageFile);
+        });
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testMetadata() throws Exception {
-        Imaging.getMetadata(imageFile);
-    }
-
-    @Test
-    public void testImageInfo() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageInfo(File imageFile) throws Exception {
         final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
         assertNotNull(imageInfo);
         // TODO assert more
     }
 
-    @Test
-    public void testImageDimensions() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageDimensions(File imageFile) throws Exception {
         final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
         final GifImageMetadata metadata = (GifImageMetadata) Imaging.getMetadata(imageFile);
         final List<BufferedImage> images = Imaging.getAllBufferedImages(imageFile);
@@ -81,15 +80,17 @@ public class GifReadTest extends GifBaseTest {
         assertEquals(height, imageInfo.getHeight());
     }
 
-    @Test
-    public void testBufferedImage() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImage(File imageFile) throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
         // TODO assert more
     }
 
-    @Test
-    public void testBufferedImages() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImages(File imageFile) throws Exception {
         final List<BufferedImage> images = Imaging.getAllBufferedImages(imageFile);
         assertTrue(images.size() > 0);
         // TODO assert more

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
@@ -17,49 +17,45 @@
 
 package org.apache.commons.imaging.formats.icns;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class IcnsReadTest extends IcnsBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getIcnsImages();
+    public static Stream<File> data() throws Exception {
+        return getIcnsImages().stream();
     }
 
-    public IcnsReadTest(final File imageFile) {
-        this.imageFile = imageFile;
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageMetadata(File imageFile) throws Exception {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getMetadata(imageFile);
+        });
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testImageMetadata() throws Exception {
-        Imaging.getMetadata(imageFile);
-    }
-
-    @Test
-    public void testImageInfo() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageInfo(File imageFile) throws Exception {
         final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, Collections.<String, Object> emptyMap());
         assertNotNull(imageInfo);
     }
 
-    @Test
-    public void testBufferedImage() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImage(File imageFile) throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
         // TODO assert more

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.icns;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.BinaryOutputStream;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IcnsRoundTripTest extends IcnsBaseTest {
     // 16x16 test image
@@ -370,7 +370,7 @@ public class IcnsRoundTripTest extends IcnsBaseTest {
             } catch (final ImageReadException imageReadException) {
                 threw = true;
             }
-            assertTrue("ICNS file with corrupt mask didn't fail to parse", threw);
+            assertTrue(threw);
         }
     }
 

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoReadTest.java
@@ -17,47 +17,46 @@
 
 package org.apache.commons.imaging.formats.ico;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class IcoReadTest extends IcoBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getIcoImages();
+    public static Stream<File> data() throws Exception {
+        return getIcoImages().stream();
     }
 
-    public IcoReadTest(final File imageFile) {
-        this.imageFile = imageFile;
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetadata(File imageFile) throws Exception {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getMetadata(imageFile);
+        });
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testMetadata() throws Exception {
-        Imaging.getMetadata(imageFile);
+    @Disabled(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testImageInfo(File imageFile) throws Exception {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            Imaging.getImageInfo(imageFile, Collections.<String, Object> emptyMap());
+        });
     }
 
-    @Ignore(value = "RoundtripTest has to be fixed befor implementation can throw UnsupportedOperationException")
-    @Test(expected = UnsupportedOperationException.class)
-    public void testImageInfo() throws Exception {
-        Imaging.getImageInfo(imageFile, Collections.<String, Object> emptyMap());
-    }
-
-    @Test
-    public void testBufferedImage() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBufferedImage(File imageFile) throws Exception {
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         assertNotNull(image);
         // TODO assert more

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.ico;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -34,7 +34,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.BinaryOutputStream;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IcoRoundtripTest extends IcoBaseTest {
     // 16x16 test image

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageReadException;
@@ -32,26 +32,18 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class JpegReadTest extends JpegBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception{
-        return getJpegImages();
+    public static Stream<File> data() throws Exception{
+        return getJpegImages().stream();
     }
 
-    public JpegReadTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(File imageFile) throws Exception {
         final Map<String, Object> params = new HashMap<>();
         final boolean ignoreImageData = isPhilHarveyTestImage(imageFile);
         params.put(ImagingConstants.PARAM_KEY_READ_THUMBNAILS, Boolean.valueOf(!ignoreImageData));

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
@@ -19,9 +19,11 @@ package org.apache.commons.imaging.formats.jpeg;
 
 import java.io.File;
 import java.util.Collections;
+
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that an invalid segment will not cause an ArrayIndexOutOfBoundsException
@@ -29,13 +31,15 @@ import org.junit.Test;
  */
 public class JpegWithInvalidDhtSegmentTest {
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testSingleImage() throws Exception {
         // we cannot use ImagingTest and getImageByFileName, as it would cause others
         // tests to fail
         final File imageFile = new File(JpegWithInvalidDhtSegmentTest.class
                 .getResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg")
                 .getFile());
-        Imaging.getMetadata(imageFile, Collections.<String, Object>emptyMap());
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            Imaging.getMetadata(imageFile, Collections.<String, Object>emptyMap());
+        });
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithJpegThumbnailTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithJpegThumbnailTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JpegWithJpegThumbnailTest extends ImagingTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/DctTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/DctTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.imaging.formats.jpeg.decoder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DctTest {
 
@@ -33,23 +33,20 @@ public class DctTest {
         final float[] transformed = REFERENCE_forwardDCT(originalData);
         final float[] reversed = REFERENCE_inverseDCT(transformed);
         for (int i = 0; i < 8; i++) {
-            assertEquals("Reference transforms broken, at x=" + i,
-                    originalData[i], reversed[i], 0.001);
+            assertEquals(originalData[i], reversed[i], 0.001);
         }
 
         final float[] data = originalData.clone();
         Dct.forwardDCT8(data);
         Dct.scaleQuantizationVector(data);
         for (int i = 0; i < 8; i++) {
-            assertEquals("Forward transform broken, at x=" + i, data[i],
-                    transformed[i], 0.001);
+            assertEquals(data[i], transformed[i], 0.001);
         }
 
         Dct.scaleDequantizationVector(data);
         Dct.inverseDCT8(data);
         for (int i = 0; i < 8; i++) {
-            assertEquals("Inverse transform broken, at x=" + i, data[i],
-                    originalData[i], 0.001);
+            assertEquals(data[i], originalData[i], 0.001);
         }
     }
 
@@ -69,8 +66,7 @@ public class DctTest {
         final float[][] reversed8x8 = REFERENCE_inverseDCT(transformed8x8);
         for (int y = 0; y < 8; y++) {
             for (int x = 0; x < 8; x++) {
-                assertEquals("Reference transforms broken, at x=" + x + ",y="
-                        + y, originalData8x8[y][x], reversed8x8[y][x], 0.001);
+                assertEquals(originalData8x8[y][x], reversed8x8[y][x], 0.001);
             }
         }
 
@@ -79,8 +75,7 @@ public class DctTest {
         Dct.scaleQuantizationMatrix(data);
         for (int y = 0; y < 8; y++) {
             for (int x = 0; x < 8; x++) {
-                assertEquals("Forward transform broken, at x=" + x + ",y=" + y,
-                        transformed8x8[y][x], data[8 * y + x], 0.001);
+                assertEquals(transformed8x8[y][x], data[8 * y + x], 0.001);
             }
         }
 
@@ -88,8 +83,7 @@ public class DctTest {
         Dct.inverseDCT8x8(data);
         for (int y = 0; y < 8; y++) {
             for (int x = 0; x < 8; x++) {
-                assertEquals("Inverse transform broken, at x=" + x + ",y=" + y,
-                        originalData8x8[y][x], data[8 * y + x], 0.001);
+                assertEquals(originalData8x8[y][x], data[8 * y + x], 0.001);
             }
         }
     }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
@@ -22,7 +22,8 @@ import java.io.IOException;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the JpegDecoder.
@@ -35,13 +36,15 @@ public class JpegDecoderTest {
      * @throws IOException
      * @throws ImageReadException
      */
-    @Test(expected = ImageReadException.class, timeout = 2000)
+    @Test
     public void testDecodeBadFile() throws ImageReadException, IOException {
         // From IMAGING-220
         final File inputFile = new File(
                 JpegDecoderTest.class.getResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg")
                         .getFile());
         final ByteSourceFile byteSourceFile = new ByteSourceFile(inputFile);
-        new JpegDecoder().decode(byteSourceFile);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            new JpegDecoder().decode(byteSourceFile);
+        });
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegInputStreamTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegInputStreamTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.imaging.formats.jpeg.decoder;
 import java.io.IOException;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link JpegInputStream}.
@@ -27,23 +28,27 @@ import org.junit.Test;
  **/
 public class JpegInputStreamTest {
 
-  @Test(expected = ImageReadException.class)
+  @Test
   public void testNextBitThrowsImageReadExceptionOne() throws IOException, ImageReadException {
     int[] byteArray = new int[6];
     byteArray[0] = (byte) (-1);
     byteArray[1] = (byte) 74;
     JpegInputStream jpegInputStream = new JpegInputStream(byteArray);
 
-    jpegInputStream.nextBit();
+    Assertions.assertThrows(ImageReadException.class, () -> {
+        jpegInputStream.nextBit();
+    });
 
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testNextBitThrowsImageReadExceptionTwo() throws IOException, ImageReadException {
     int[] byteArray = new int[0];
     JpegInputStream jpegInputStream = new JpegInputStream(byteArray);
 
-    jpegInputStream.nextBit();
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+        jpegInputStream.nextBit();
+    });
 
   }
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/AsciiFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/AsciiFieldTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.imaging.formats.jpeg.exif;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
@@ -32,7 +32,7 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AsciiFieldTest extends ExifBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifDumpTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.imaging.formats.jpeg.exif;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
@@ -31,34 +31,27 @@ import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegUtils;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ExifDumpTest extends ExifBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithExifData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithExifData().stream();
     }
 
-    public ExifDumpTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void testDumpJFIF() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testDumpJFIF(File imageFile) throws Exception {
         final ByteSource byteSource = new ByteSourceFile(imageFile);
         Debug.debug("Segments:");
         new JpegUtils().dumpJFIF(byteSource);
         // TODO assert someting
     }
 
-    @Test
-    public void testMetadata() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetadata(File imageFile) throws Exception {
         final Map<String, Object> params = new HashMap<>();
         final boolean ignoreImageData = isPhilHarveyTestImage(imageFile);
         params.put(ImagingConstants.PARAM_KEY_READ_THUMBNAILS, Boolean.valueOf(!ignoreImageData));

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.imaging.formats.jpeg.exif;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -49,8 +49,8 @@ import org.apache.commons.imaging.formats.tiff.fieldtypes.FieldType;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExifRewriteTest extends ExifBaseTest {
     // public ExifRewriteTest(String name)
@@ -77,7 +77,7 @@ public class ExifRewriteTest extends ExifBaseTest {
 
             {
                 final JpegImageMetadata metadata = (JpegImageMetadata) Imaging.getMetadata(imageFile);
-                Assert.assertNotNull(metadata);
+                Assertions.assertNotNull(metadata);
             }
 
             {
@@ -382,11 +382,8 @@ public class ExifRewriteTest extends ExifBaseTest {
                 if (!oldField.getTagInfo().isOffset()) {
                     if (oldField.getTagInfo().isText()) { /* do nothing */
                     } else if (oldField.isLocalValue()) {
-                        final String label = imageFile.getName() + ", dirType[" + i
-                                + "]=" + dirType + ", fieldTag[" + j + "]="
-                                + fieldTag;
                         if (oldField.getTag() == 0x116 || oldField.getTag() == 0x117) {
-                            assertEquals(label, oldField.getValue(), newField.getValue());
+                            assertEquals(oldField.getValue(), newField.getValue());
                         } else {
                             assertEquals(oldField.getBytesLength(), newField.getBytesLength());
                             assertArrayEquals(oldField.getByteArrayValue(), newField.getByteArrayValue());

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/GpsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/GpsTest.java
@@ -18,35 +18,27 @@
 package org.apache.commons.imaging.formats.jpeg.exif;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class GpsTest extends ExifBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithExifData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithExifData().stream();
     }
 
-    public GpsTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(File imageFile) throws Exception {
         if (imageFile.getParentFile().getName().toLowerCase().equals("@broken")) {
             return;
         }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MakerNoteFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MakerNoteFieldTest.java
@@ -28,10 +28,6 @@ import org.apache.commons.imaging.internal.Debug;
 
 public class MakerNoteFieldTest extends SpecificExifTagTest {
 
-    public MakerNoteFieldTest(final File imageFile) {
-        super(imageFile);
-    }
-
     @Override
     protected void checkField(final File imageFile, final TiffField field)
             throws IOException, ImageReadException, ImageWriteException {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MicrosoftTagTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MicrosoftTagTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.jpeg.exif;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -42,7 +42,7 @@ import org.apache.commons.imaging.formats.tiff.constants.MicrosoftTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputDirectory;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MicrosoftTagTest extends ExifBaseTest {
     private static final String AUTHOR = "author";

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/SpecificExifTagTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/SpecificExifTagTest.java
@@ -19,10 +19,10 @@ package org.apache.commons.imaging.formats.jpeg.exif;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
@@ -32,26 +32,18 @@ import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public abstract class SpecificExifTagTest extends ExifBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithExifData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithExifData().stream();
     }
 
-    public SpecificExifTagTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void testAllImages() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAllImages(File imageFile) throws Exception {
         if (imageFile.getParentFile().getName().toLowerCase().equals("@broken")) {
             return;
         }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
@@ -27,13 +27,9 @@ import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TextFieldTest extends SpecificExifTagTest {
-
-    public TextFieldTest(final File imageFile) {
-        super(imageFile);
-    }
 
     @Override
     protected void checkField(final File imageFile, final TiffField field)
@@ -52,7 +48,7 @@ public class TextFieldTest extends SpecificExifTagTest {
 
         try {
             final Object textFieldValue = field.getValue();
-            Assert.assertNotNull(textFieldValue);
+            Assertions.assertNotNull(textFieldValue);
             // TODO what else to assert?
         } catch (final ImageReadException e) {
             Debug.debug("imageFile", imageFile.getAbsoluteFile());

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.imaging.formats.jpeg.exif;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.examples.WriteExifMetadataExample;
@@ -28,30 +28,22 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class WriteExifMetadataExampleTest extends ExifBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getJpegImages();
-    }
-
-    public WriteExifMetadataExampleTest(final File imageFile) {
-        this.imageFile = imageFile;
+    public static Stream<File> data() throws Exception {
+        return getJpegImages().stream();
     }
 
     /**
      * Test that there are no odd offsets in the generated TIFF images.
      * @throws Exception if the test failed for a unexpected reason
      */
-    @Test
-    public void testOddOffsets() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOddOffsets(File imageFile) throws Exception {
         Debug.debug("imageFile", imageFile.getAbsoluteFile());
 
         final File tempFile = createTempFile("test", ".jpg");
@@ -68,11 +60,8 @@ public class WriteExifMetadataExampleTest extends ExifBaseTest {
             final TiffImageMetadata tiff = parser.getExifMetadata(byteSource, null);
             for (final TiffField tiffField : tiff.getAllFields()) {
                 if (!tiffField.isLocalValue()) {
-                    final int offset = tiffField.getOffset();
-                    final String tag = tiffField.getTagName();
-                    final String message = String.format("Odd offset %d, field %s", offset, tag);
                     final boolean isOdd = (tiffField.getOffset() & 1l) == 0;
-                    assertTrue(message, isOdd);
+                    assertTrue(isOdd);
                 }
             }
         } catch (final ExifRewriter.ExifOverflowException e) {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
@@ -17,48 +17,40 @@
 
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegPhotoshopMetadata;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class IptcAddTest extends IptcBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getJpegImages();
-    }
-
-    public IptcAddTest(final File imageFile) {
-        this.imageFile = imageFile;
+    public static Stream<File> data() throws Exception {
+        return getJpegImages().stream();
     }
 
     /*
          * Add a few IPTC values to JPEG images, whether or not they have existing
          * IPTC data.
          */
-    @Test
-    public void testAddIptcData() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAddIptcData(File imageFile) throws Exception {
         final ByteSource byteSource = new ByteSourceFile(imageFile);
 
         final Map<String, Object> params = new HashMap<>();

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcDumpTest.java
@@ -17,39 +17,31 @@
 
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegPhotoshopMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class IptcDumpTest extends IptcBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithIptcData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithIptcData().stream();
     }
 
-    public IptcDumpTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(File imageFile) throws Exception {
         final Map<String, Object> params = new HashMap<>();
         final boolean ignoreImageData = isPhilHarveyTestImage(imageFile);
         params.put(ImagingConstants.PARAM_KEY_READ_THUMBNAILS, Boolean.valueOf(!ignoreImageData));

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcFullDiscardTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcFullDiscardTest.java
@@ -24,8 +24,8 @@ import java.util.Collections;
 
 import javax.imageio.ImageIO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IptcFullDiscardTest {
 
@@ -57,7 +57,7 @@ public class IptcFullDiscardTest {
         final byte[] originalImage = generateImage();
         final byte[] taggedImage = addMetaData(originalImage);
         final byte[] untaggedImage = removeMetaData(taggedImage, false);
-        Assert.assertEquals(18, untaggedImage.length - originalImage.length);
+        Assertions.assertEquals(18, untaggedImage.length - originalImage.length);
     }
 
     @Test
@@ -65,6 +65,6 @@ public class IptcFullDiscardTest {
         final byte[] originalImage = generateImage();
         final byte[] taggedImage = addMetaData(originalImage);
         final byte[] untaggedImage = removeMetaData(taggedImage, true);
-        Assert.assertEquals(originalImage.length, untaggedImage.length);
+        Assertions.assertEquals(originalImage.length, untaggedImage.length);
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcTypeLookupTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcTypeLookupTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IptcTypeLookupTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/App2SegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/App2SegmentTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.commons.imaging.formats.jpeg.segments;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link App2Segment}.

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/AppnSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/AppnSegmentTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.imaging.formats.jpeg.segments;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AppnSegmentTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/JfifSegmentTest.java
@@ -17,12 +17,12 @@
 package org.apache.commons.imaging.formats.jpeg.segments;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JfifSegmentTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/NegSizeSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/NegSizeSegmentTest.java
@@ -21,15 +21,15 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegUtils;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceInputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class NegSizeSegmentTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegmentTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.imaging.formats.jpeg.segments;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SosSegmentTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
@@ -16,7 +16,7 @@
 
 package org.apache.commons.imaging.formats.jpeg.specific;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -26,7 +26,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.decoder.JpegDecoderTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic tests for JpegImageParser.

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpDumpTest.java
@@ -17,36 +17,28 @@
 
 package org.apache.commons.imaging.formats.jpeg.xmp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class JpegXmpDumpTest extends JpegXmpBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithXmpData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithXmpData().stream();
     }
 
-    public JpegXmpDumpTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(File imageFile) throws Exception {
         final ByteSource byteSource = new ByteSourceFile(imageFile);
         final Map<String, Object> params = new HashMap<>();
         final String xmpXml = new JpegImageParser().getXmpXml(byteSource, params);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpParserTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.imaging.formats.jpeg.xmp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JpegXmpParserTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
@@ -17,41 +17,33 @@
 
 package org.apache.commons.imaging.formats.jpeg.xmp;
 
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSource;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class JpegXmpRewriteTest extends JpegXmpBaseTest {
 
-    private final File imageFile;
-
-    @Parameterized.Parameters
-    public static Collection<File> data() throws Exception {
-        return getImagesWithXmpData();
+    public static Stream<File> data() throws Exception {
+        return getImagesWithXmpData().stream();
     }
 
-    public JpegXmpRewriteTest(final File imageFile) {
-        this.imageFile = imageFile;
-    }
-
-    @Test
-    public void testRemoveInsertUpdate() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRemoveInsertUpdate(File imageFile) throws Exception {
         final ByteSource byteSource = new ByteSourceFile(imageFile);
         final Map<String, Object> params = new HashMap<>();
         final String xmpXml = new JpegImageParser().getXmpXml(byteSource, params);
@@ -71,7 +63,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
 
             final String outXmp = new JpegImageParser().getXmpXml(
                     new ByteSourceFile(noXmpFile), params);
-            assertNull(outXmp);
+            Assertions.assertNull(outXmp);
         }
 
         {

--- a/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.pam;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -29,8 +29,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PamReadTest extends PamBaseTest {
 
@@ -45,7 +45,7 @@ public class PamReadTest extends PamBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.pcx;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -29,8 +29,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PcxReadTest extends PcxBaseTest {
 
@@ -45,7 +45,7 @@ public class PcxReadTest extends PcxBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/RleReaderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/RleReaderTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging.formats.pcx;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RleReaderTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConvertPngToGifTest extends PngBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PhysicalScaleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PhysicalScaleTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.imaging.formats.png;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PhysicalScaleTest {
    private static final double delta = 0.01;
@@ -29,19 +29,19 @@ public class PhysicalScaleTest {
    public void createFromMeters() {
       final PhysicalScale physicalScale = PhysicalScale.createFromMeters(1.0, 2.0);
 
-      assertTrue("Should be in meteres", physicalScale.isInMeters());
-      assertFalse("Should not be in radians", physicalScale.isInRadians());
-      assertEquals("Invalid horizontal units per pixel", physicalScale.getHorizontalUnitsPerPixel(), 1.0, delta);
-      assertEquals("Invalid vertical units per pixel", physicalScale.getVerticalUnitsPerPixel(), 2.0, delta);
+      assertTrue(physicalScale.isInMeters());
+      assertFalse(physicalScale.isInRadians());
+      assertEquals(physicalScale.getHorizontalUnitsPerPixel(), 1.0, delta);
+      assertEquals(physicalScale.getVerticalUnitsPerPixel(), 2.0, delta);
    }
 
    @Test
    public void createFromRadians() {
       final PhysicalScale physicalScale = PhysicalScale.createFromRadians(2.0, 1.0);
 
-      assertFalse("Should not be in meteres", physicalScale.isInMeters());
-      assertTrue("Should be in radians", physicalScale.isInRadians());
-      assertEquals("Invalid horizontal units per pixel", physicalScale.getHorizontalUnitsPerPixel(), 2.0, delta);
-      assertEquals("Invalid vertical units per pixel", physicalScale.getVerticalUnitsPerPixel(), 1.0, delta);
+      assertFalse(physicalScale.isInMeters());
+      assertTrue(physicalScale.isInRadians());
+      assertEquals(physicalScale.getHorizontalUnitsPerPixel(), 2.0, delta);
+      assertEquals(physicalScale.getVerticalUnitsPerPixel(), 1.0, delta);
    }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngCrcTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngCrcTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.png;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for class {@link PngCrc}.

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -29,7 +29,7 @@ import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FilenameUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PngMultipleRoundtripTest extends PngBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -28,8 +28,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PngReadTest extends PngBaseTest {
 
@@ -62,7 +62,7 @@ public class PngReadTest extends PngBaseTest {
                 }
             } else {
                 final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-                Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+                Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
                 final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
                 assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -32,7 +32,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PngTextTest extends PngBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
@@ -27,7 +27,8 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.examples.ImageReadExample.ManagedImageBufferedImageFactory;
 import org.apache.commons.imaging.formats.jpeg.JpegWithInvalidDhtSegmentTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for PNG files with invalid chunk sizes.
@@ -41,13 +42,15 @@ public class PngWithInvalidPngChunkSizeTest {
 	 * @throws IOException        if it fails to read from the input source
 	 * @throws ImageReadException if it fails to read the image
 	 */
-	@Test(expected = ImageReadException.class)
+	@Test
 	public void testPngWithInvalidPngChunkSize() throws IOException, ImageReadException {
 		final File imageFile = new File(
 				JpegWithInvalidDhtSegmentTest.class.getResource("/IMAGING-211/testfile_2.png").getFile());
 		final Map<String, Object> params = new HashMap<>();
 		params.put(ImagingConstants.BUFFERED_IMAGE_FACTORY, new ManagedImageBufferedImageFactory());
-		Imaging.getBufferedImage(imageFile, params);
+		Assertions.assertThrows(ImageReadException.class, () -> {
+		    Imaging.getBufferedImage(imageFile, params);
+		});
 	}
 
 	/**
@@ -57,12 +60,14 @@ public class PngWithInvalidPngChunkSizeTest {
      * @throws IOException        if it fails to read from the input source
      * @throws ImageReadException if it fails to read the image
      */
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testPngWithInvalidNegativePngChunkSize() throws IOException, ImageReadException {
         final File imageFile = new File(
                 JpegWithInvalidDhtSegmentTest.class.getResource("/IMAGING-210/testfile.png").getFile());
         final Map<String, Object> params = new HashMap<>();
         params.put(ImagingConstants.BUFFERED_IMAGE_FACTORY, new ManagedImageBufferedImageFactory());
-        Imaging.getBufferedImage(imageFile, params);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            Imaging.getBufferedImage(imageFile, params);
+        });
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PngWriteForceTrueColorText extends PngBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -39,7 +39,7 @@ import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PngWriteReadTest extends ImagingTest {
     // public PngWriteReadTest(String name)
@@ -130,9 +130,9 @@ public class PngWriteReadTest extends ImagingTest {
               ImageFormats.PNG, optionalParams);
         final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(pngBytes);
         final PhysicalScale physicalScale = imageInfo.getPhysicalScale();
-        assertTrue("Invalid units", physicalScale.isInMeters());
-        assertEquals("Invalid horizontal units", 0.01, physicalScale.getHorizontalUnitsPerPixel(), 0.001);
-        assertEquals("Invalid vertical units", 0.02, physicalScale.getVerticalUnitsPerPixel(), 0.001);
+        assertTrue(physicalScale.isInMeters());
+        assertEquals(0.01, physicalScale.getHorizontalUnitsPerPixel(), 0.001);
+        assertEquals(0.02, physicalScale.getVerticalUnitsPerPixel(), 0.001);
     }
 
     @Test
@@ -146,9 +146,9 @@ public class PngWriteReadTest extends ImagingTest {
               ImageFormats.PNG, optionalParams);
         final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(pngBytes);
         final PhysicalScale physicalScale = imageInfo.getPhysicalScale();
-        assertTrue("Invalid units", physicalScale.isInRadians());
-        assertEquals("Invalid horizontal units", 0.01, physicalScale.getHorizontalUnitsPerPixel(), 0.001);
-        assertEquals("Invalid vertical units", 0.02, physicalScale.getVerticalUnitsPerPixel(), 0.001);
+        assertTrue(physicalScale.isInRadians());
+        assertEquals(0.01, physicalScale.getHorizontalUnitsPerPixel(), 0.001);
+        assertEquals(0.02, physicalScale.getVerticalUnitsPerPixel(), 0.001);
     }
 
     private BufferedImage imageDataToBufferedImage(final int[][] rawData) {

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.png.chunks;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,7 +28,8 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PngChunkIccp}.
@@ -37,10 +38,12 @@ public class PngChunkIccpTest {
 
     private static final int chunkType = 1766015824;
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testErrorOnNoProfileName() throws ImageReadException, IOException {
         final byte[] data = new byte[0];
-        new PngChunkIccp(0, chunkType, 0, data);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            new PngChunkIccp(0, chunkType, 0, data);
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkScalTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkScalTest.java
@@ -17,11 +17,12 @@
 package org.apache.commons.imaging.formats.png.chunks;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PngChunkScalTest {
    private static final double delta = 0.001;
@@ -32,9 +33,9 @@ public class PngChunkScalTest {
       final PngChunkScal pngChunkScal = new PngChunkScal(10, chunkType, 0,
             new byte[]{1, 48, 46, 48, 49, 0, 48, 46, 48, 50});
 
-      assertEquals("Invalid unit specifier", pngChunkScal.unitSpecifier, 1);
-      assertEquals("Invalid units per pixel x axis", pngChunkScal.unitsPerPixelXAxis, 0.01, delta);
-      assertEquals("Invalid units per pixel y axis", pngChunkScal.unitsPerPixelYAxis, 0.02, delta);
+      assertEquals(pngChunkScal.unitSpecifier, 1);
+      assertEquals(pngChunkScal.unitsPerPixelXAxis, 0.01, delta);
+      assertEquals(pngChunkScal.unitsPerPixelYAxis, 0.02, delta);
    }
 
    @Test
@@ -42,33 +43,43 @@ public class PngChunkScalTest {
       final PngChunkScal pngChunkScal = new PngChunkScal(10, chunkType, 0,
             new byte[]{2, 48, 46, 48, 49, 0, 48, 46, 48, 50});
 
-      assertEquals("Invalid unit specifier", pngChunkScal.unitSpecifier, 2);
-      assertEquals("Invalid units per pixel x axis", pngChunkScal.unitsPerPixelXAxis, 0.01, delta);
-      assertEquals("Invalid units per pixel y axis", pngChunkScal.unitsPerPixelYAxis, 0.02, delta);
+      assertEquals(pngChunkScal.unitSpecifier, 2);
+      assertEquals(pngChunkScal.unitsPerPixelXAxis, 0.01, delta);
+      assertEquals(pngChunkScal.unitsPerPixelYAxis, 0.02, delta);
    }
 
-   @Test(expected = ImageReadException.class)
+   @Test
    public void testConstruct_InvalidUnitSpecifier() throws IOException, ImageReadException {
-      new PngChunkScal(10, chunkType, 0, new byte[]{3, 48, 46, 48, 49, 0, 48, 46, 48, 50});
+       Assertions.assertThrows(ImageReadException.class,() -> {
+           new PngChunkScal(10, chunkType, 0, new byte[]{3, 48, 46, 48, 49, 0, 48, 46, 48, 50});
+       });
    }
 
-   @Test(expected = ImageReadException.class)
+   @Test
    public void testConstruct_MissingSeparator() throws IOException, ImageReadException {
-      new PngChunkScal(9, chunkType, 0, new byte[]{1, 48, 46, 48, 49, 48, 46, 48, 50});
+      Assertions.assertThrows(ImageReadException.class,() -> {
+          new PngChunkScal(9, chunkType, 0, new byte[]{1, 48, 46, 48, 49, 48, 46, 48, 50});
+      });
    }
 
-   @Test(expected = ImageReadException.class)
+   @Test
    public void testConstruct_InvalidDblValue() throws IOException, ImageReadException {
-      new PngChunkScal(10, chunkType, 0, new byte[]{2, 65, 46, 48, 49, 0, 48, 46, 48, 50});
+       Assertions.assertThrows(ImageReadException.class,() -> {
+           new PngChunkScal(10, chunkType, 0, new byte[]{2, 65, 46, 48, 49, 0, 48, 46, 48, 50});
+       });
    }
 
-   @Test(expected = ImageReadException.class)
+   @Test
    public void testConstruct_MissingXValue() throws IOException, ImageReadException {
-      new PngChunkScal(2, chunkType, 0, new byte[]{2, 0});
+      Assertions.assertThrows(ImageReadException.class,() -> {
+          new PngChunkScal(2, chunkType, 0, new byte[]{2, 0});
+      });
    }
 
-   @Test(expected = ImageReadException.class)
+   @Test
    public void testConstruct_MissingYValue() throws IOException, ImageReadException {
-      new PngChunkScal(6, chunkType, 0, new byte[]{2, 48, 46, 48, 49, 0});
+       Assertions.assertThrows(ImageReadException.class,() -> {
+           new PngChunkScal(6, chunkType, 0, new byte[]{2, 48, 46, 48, 49, 0});
+       });
    }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkTextTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.imaging.formats.png.chunks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PngChunkTextTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterAverageTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterAverageTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.png.scanlinefilters;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ScanlineFilterAverageTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterPaethTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterPaethTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.png.scanlinefilters;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ScanlineFilterPaethTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterUpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/scanlinefilters/ScanlineFilterUpTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.png.scanlinefilters;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ScanlineFilterUpTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/transparencyfilters/TransparencyFilterIndexedColorTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/transparencyfilters/TransparencyFilterIndexedColorTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.imaging.formats.png.transparencyfilters;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TransparencyFilterIndexedColorTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PbmFileInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PbmFileInfoTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.commons.imaging.formats.pnm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PbmFileInfoTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PgmFileInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PgmFileInfoTest.java
@@ -16,21 +16,26 @@
  */
 package org.apache.commons.imaging.formats.pnm;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PgmFileInfoTest {
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testCreateThrowsImageReadExceptionOne() throws ImageReadException {
-        new PgmFileInfo(16711680, 16711680, false, 16711680);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            new PgmFileInfo(16711680, 16711680, false, 16711680);
+        });
     }
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testCreateThrowsImageReadExceptionTwo() throws ImageReadException {
-        new PgmFileInfo(0, 0, true, 0);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            new PgmFileInfo(0, 0, true, 0);
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
@@ -30,11 +30,12 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PnmImageParserTest {
 
@@ -80,27 +81,33 @@ public class PnmImageParserTest {
      * If an invalid width is specified, should throw {@link ImageReadException} rather than
      * {@link NumberFormatException}.
      */
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testGetImageInfo_invalidWidth() throws ImageReadException, IOException {
         final byte[] bytes = "P1\na 2\n0 0 0 0 0 0 0 0 0 0 0\n1 1 1 1 1 1 1 1 1 1 1\n".getBytes(US_ASCII);
         final Map<String, Object> params = Collections.emptyMap();
         final PnmImageParser underTest = new PnmImageParser();
-        underTest.getImageInfo(bytes, params);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            underTest.getImageInfo(bytes, params);
+        });
     }
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testGetImageInfo_invalidHeight() throws ImageReadException, IOException {
         final byte[] bytes = "P1\n2 a\n0 0\n0 0\n0 0\n0 0\n0 0\n0 1\n1 1\n1 1\n1 1\n1 1\n1 1\n".getBytes(US_ASCII);
         final Map<String, Object> params = Collections.emptyMap();
         final PnmImageParser underTest = new PnmImageParser();
-        underTest.getImageInfo(bytes, params);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            underTest.getImageInfo(bytes, params);
+        });
     }
 
-    @Test(expected = ImageReadException.class)
+    @Test
     public void testGetImageInfo_missingWidthValue() throws ImageReadException, IOException {
         final byte[] bytes = "P7\nWIDTH \n".getBytes(US_ASCII);
         final Map<String, Object> params = Collections.emptyMap();
         final PnmImageParser underTest = new PnmImageParser();
-        underTest.getImageInfo(bytes, params);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            underTest.getImageInfo(bytes, params);
+        });
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PpmFileInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PpmFileInfoTest.java
@@ -17,7 +17,8 @@
 package org.apache.commons.imaging.formats.pnm;
 
 import org.apache.commons.imaging.ImageReadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link PpmFileInfo}.
@@ -26,14 +27,18 @@ import org.junit.Test;
  **/
 public class PpmFileInfoTest {
 
-  @Test(expected = ImageReadException.class)
+  @Test
   public void testCreatesPpmFileInfoOne() throws ImageReadException {
-      new PpmFileInfo(0, 0, false, 16711680);
+      Assertions.assertThrows(ImageReadException.class, () -> {
+          new PpmFileInfo(0, 0, false, 16711680);
+      });
   }
 
-  @Test(expected = ImageReadException.class)
+  @Test
   public void testCreatesPpmFileInfoThree() throws ImageReadException {
-      new PpmFileInfo(0, 0, true, 0);
+      Assertions.assertThrows(ImageReadException.class, () -> {
+          new PpmFileInfo(0, 0, true, 0);
+      });
   }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/WhiteSpaceReaderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/WhiteSpaceReaderTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.imaging.formats.pnm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WhiteSpaceReaderTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/ImageResourceBlockTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/ImageResourceBlockTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImageResourceBlockTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/ImageResourceTypeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/ImageResourceTypeTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImageResourceTypeTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -28,8 +28,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PsdReadTest extends PsdBaseTest {
 
@@ -43,7 +43,7 @@ public class PsdReadTest extends PsdBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserCmykTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserCmykTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.psd.dataparsers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DataParserCmykTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserGrayscaleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserGrayscaleTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.psd.dataparsers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DataParserGrayscaleTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserIndexedTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserIndexedTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.imaging.formats.psd.dataparsers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DataParserIndexedTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserLabTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/dataparsers/DataParserLabTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.psd.dataparsers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DataParserLabTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.rgbe;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -31,7 +31,8 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RgbeReadTest extends RgbeBaseTest {
 
@@ -62,7 +63,7 @@ public class RgbeReadTest extends RgbeBaseTest {
      * @throws ImageReadException
      * @throws IOException
      */
-    @Test(expected = ImageReadException.class, timeout = 2000)
+    @Test
     public void testErrorDecompressingInvalidFile() throws ImageReadException, IOException {
         // From IMAGING-219
         final File inputFile = new File(
@@ -70,6 +71,8 @@ public class RgbeReadTest extends RgbeBaseTest {
                         .getFile());
         final ByteSourceFile byteSourceFile = new ByteSourceFile(inputFile);
         final Map<String, Object> params = Collections.<String, Object>emptyMap();
-        new RgbeImageParser().getBufferedImage(byteSourceFile, params);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            new RgbeImageParser().getBufferedImage(byteSourceFile, params);
+        });
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/JpegImageDataTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/JpegImageDataTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.tiff;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JpegImageDataTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffCcittTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffCcittTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -32,7 +32,7 @@ import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.itu_t4.T4AndT6Compression;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffCcittTest extends TiffBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffLzwTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffLzwTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -34,8 +34,8 @@ import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.common.mylzw.MyLzwCompressor;
 import org.apache.commons.imaging.common.mylzw.MyLzwDecompressor;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TiffLzwTest extends TiffBaseTest {
 
@@ -58,7 +58,7 @@ public class TiffLzwTest extends TiffBaseTest {
         }
     }
 
-    @Ignore // FIXME fails with java.io.IOException: Bad Code: -1 codes: 258 code_size: 9, table: 4096
+    @Disabled // FIXME fails with java.io.IOException: Bad Code: -1 codes: 258 code_size: 9, table: 4096
     @Test
     public void testTiffImageData() throws IOException, ImageReadException {
         final List<File> images = getTiffImages();

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -27,7 +27,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffReadTest extends TiffBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadWriteTagsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadWriteTagsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,7 +35,7 @@ import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
 import org.apache.commons.imaging.formats.tiff.write.TiffImageWriterLossy;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputDirectory;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffReadWriteTagsTest extends TiffBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -32,7 +32,7 @@ import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffRoundtripTest extends TiffBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffSubImageTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffSubImageTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffSubImageTest extends TiffBaseTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffTagIntegrityTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffTagIntegrityTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.tiff;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import org.apache.commons.imaging.formats.tiff.constants.TiffEpTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.WangTagConstants;
 import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TiffTagIntegrityTest extends ImagingTest {
 
@@ -108,11 +108,11 @@ public class TiffTagIntegrityTest extends ImagingTest {
         Collections.sort(fieldTags);
         final Set<Integer> allTagSet = new TreeSet<>();
         for (final TagInfo tagInfo : allTags) {
-            assertTrue("Missing field " + tagInfo.tag, Collections.binarySearch(fieldTags, tagInfo.tag) >= 0);
+            assertTrue(Collections.binarySearch(fieldTags, tagInfo.tag) >= 0);
             allTagSet.add(tagInfo.tag);
         }
         for (final Integer tag : fieldTags) {
-            assertTrue("Missing tag " + tag, allTagSet.contains(tag));
+            assertTrue(allTagSet.contains(tag));
         }
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffTagsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffTagsTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.imaging.formats.tiff;
 
 import org.apache.commons.imaging.formats.tiff.taginfos.TagInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TiffTagsTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderStripsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderStripsTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.formats.tiff.datareaders;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class DataReaderStripsTest {
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAsciiTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAsciiTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.formats.tiff.TiffField;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link FieldTypeAscii}.
@@ -31,15 +32,16 @@ import org.junit.Test;
  **/
 public class FieldTypeAsciiTest {
 
-  @Test(expected = ImageWriteException.class)
+  @Test
   public void testCreatesFieldTypeAsciiAndCallsWriteData() throws ImageWriteException {
       FieldTypeAscii fieldTypeAscii = new FieldTypeAscii(0, "1");
       byte[] byteArray = new byte[1];
       ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
       TiffField tiffField = new TiffField(0, 0, fieldTypeAscii, 0L, 0, byteArray, byteOrder, 1);
 
-      fieldTypeAscii.writeData(tiffField, byteOrder);
-
+      Assertions.assertThrows(ImageWriteException.class, () -> {
+          fieldTypeAscii.writeData(tiffField, byteOrder);
+      });
   }
 
   @Test

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeByteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeByteTest.java
@@ -17,18 +17,21 @@
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
 import org.apache.commons.imaging.ImageWriteException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
 public class FieldTypeByteTest{
 
-  @Test(expected = ImageWriteException.class)
+  @Test
   public void testWriteDataWithNull() throws ImageWriteException {
       final FieldTypeByte fieldTypeByte = FieldType.UNDEFINED;
       final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
 
-      fieldTypeByte.writeData( null, byteOrder);
+      Assertions.assertThrows(ImageWriteException.class, () -> {
+          fieldTypeByte.writeData( null, byteOrder);          
+      });
   }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeLongTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeLongTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FieldTypeLongTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRationalTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRationalTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImageWriteException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link FieldTypeRational}.
@@ -39,13 +40,13 @@ public class FieldTypeRationalTest {
       assertArrayEquals(new byte[] {(byte)11, (byte)0, (byte)0, (byte)0, (byte)5, (byte)0, (byte)0, (byte)0}, byteArray);
   }
 
-  @Test(expected = ImageWriteException.class)
+  @Test
   public void testWriteDataWithNonNull() throws ImageWriteException {
       FieldTypeRational fieldTypeRational = new FieldTypeRational((-922), "z_AX");
       ByteOrder byteOrder = ByteOrder.nativeOrder();
-
-      fieldTypeRational.writeData("z_AX", byteOrder);
-
+      Assertions.assertThrows(ImageWriteException.class, () -> {
+          fieldTypeRational.writeData("z_AX", byteOrder);
+      });
   }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeShortTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeShortTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FieldTypeShortTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FieldTypeTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -16,15 +16,16 @@
  */
 package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterLogLuv.TristimulusValues;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PhotometricInterpreterLogLuvTest {
 
@@ -36,7 +37,7 @@ public class PhotometricInterpreterLogLuvTest {
     private int width = 800;
     private int height = 600;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         p = new PhotometricInterpreterLogLuv(samplesPerPixel, bitsPerSample, predictor,
                 width, height);
@@ -87,14 +88,18 @@ public class PhotometricInterpreterLogLuvTest {
         assertEquals(23, p.getRgbValues(triValues).b);
     }
 
-    @Test(expected=ImageReadException.class)
+    @Test
     public void testInterpretPixelNullSamples() throws ImageReadException, IOException {
-        p.interpretPixel(null, null, 0, 0);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            p.interpretPixel(null, null, 0, 0);
+        });
     }
 
-    @Test(expected=ImageReadException.class)
+    @Test
     public void testInterpretPixelEmptySamples() throws ImageReadException, IOException {
-        p.interpretPixel(null, new int[] {}, 0, 0);
+        Assertions.assertThrows(ImageReadException.class, () -> {
+            p.interpretPixel(null, new int[] {}, 0, 0);
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoByteOrShortTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoByteOrShortTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TagInfoByteOrShortTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoByteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoByteTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TagInfoByteTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSByteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSByteTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TagInfoSByteTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSBytesTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSBytesTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class TagInfoSBytesTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSLongTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSLongTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TagInfoSLongTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSShortTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSShortTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TagInfoSShortTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSShortsTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoSShortsTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TagInfoSShortsTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoUnknownTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoUnknownTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.imaging.formats.tiff.taginfos;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TagInfoUnknownTest{
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectoryTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectoryTest.java
@@ -17,20 +17,20 @@
 package org.apache.commons.imaging.formats.tiff.write;
 
 import static org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants.TIFF_TAG_DOCUMENT_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TiffOutputDirectoryTest {
 
     private TiffOutputDirectory directory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         directory = new TiffOutputDirectory(TiffDirectoryConstants.DIRECTORY_TYPE_ROOT, TiffConstants.DEFAULT_TIFF_BYTE_ORDER);
     }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSetTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSetTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.commons.imaging.formats.tiff.write;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TiffOutputSetTest {
 
     private TiffOutputSet tiffOutputSet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         tiffOutputSet = new TiffOutputSet();
     }

--- a/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.commons.imaging.formats.wbmp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -26,8 +26,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WbmpReadTest extends WbmpBaseTest {
 
@@ -41,7 +41,7 @@ public class WbmpReadTest extends WbmpBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.commons.imaging.formats.xbm;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -26,8 +26,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class XbmReadTest extends XbmBaseTest {
 
@@ -41,7 +41,7 @@ public class XbmReadTest extends XbmBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpDumpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.imaging.formats.xmp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class XmpDumpTest extends ImagingTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.commons.imaging.formats.xmp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -31,7 +31,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class XmpUpdateTest extends ImagingTest {
 

--- a/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.commons.imaging.formats.xpm;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -26,8 +26,8 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class XpmReadTest extends XpmBaseTest {
 
@@ -41,7 +41,7 @@ public class XpmReadTest extends XpmBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assert.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final Map<String, Object> params = new HashMap<>();
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile, params);

--- a/src/test/java/org/apache/commons/imaging/palette/DitheringTest.java
+++ b/src/test/java/org/apache/commons/imaging/palette/DitheringTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.commons.imaging.palette;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.imaging.ImageWriteException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for class {@link Dithering}.

--- a/src/test/java/org/apache/commons/imaging/palette/PaletteQuantizationTest.java
+++ b/src/test/java/org/apache/commons/imaging/palette/PaletteQuantizationTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.imaging.palette;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
 
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.ImagingTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaletteQuantizationTest extends ImagingTest {
 

--- a/src/test/java/org/apache/commons/imaging/palette/SimplePaletteTest.java
+++ b/src/test/java/org/apache/commons/imaging/palette/SimplePaletteTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging.palette;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SimplePaletteTest{
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.imaging.roundtrip;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 final class ImageAsserts {
 
@@ -37,8 +37,8 @@ final class ImageAsserts {
     }
 
     static void assertEquals(final BufferedImage a, final BufferedImage b, final int tolerance) {
-        Assert.assertEquals(a.getWidth(), b.getWidth());
-        Assert.assertEquals(a.getHeight(), b.getHeight());
+        Assertions.assertEquals(a.getWidth(), b.getWidth());
+        Assertions.assertEquals(a.getHeight(), b.getHeight());
 
         for (int x = 0; x < a.getWidth(); x++) {
             for (int y = 0; y < a.getHeight(); y++) {
@@ -58,7 +58,7 @@ final class ImageAsserts {
                     Debug.debug("a_argb: " + a_argb + " (0x" + Integer.toHexString(a_argb) + ")");
                     Debug.debug("b_argb: " + b_argb + " (0x" + Integer.toHexString(b_argb) + ")");
                 }
-                Assert.assertEquals(a_argb, b_argb);
+                Assertions.assertEquals(a_argb, b_argb);
             }
         }
     }
@@ -81,7 +81,7 @@ final class ImageAsserts {
     static void assertEquals(final File a, final File b) throws IOException {
         assertTrue(a.exists() && a.isFile());
         assertTrue(b.exists() && b.isFile());
-        Assert.assertEquals(a.length(), b.length());
+        Assertions.assertEquals(a.length(), b.length());
 
         final byte aData[] = FileUtils.readFileToByteArray(a);
         final byte bData[] = FileUtils.readFileToByteArray(b);
@@ -97,7 +97,7 @@ final class ImageAsserts {
                 Debug.debug("aByte: " + aByte + " (0x" + Integer.toHexString(aByte) + ")");
                 Debug.debug("bByte: " + bByte + " (0x" + Integer.toHexString(bByte) + ")");
             }
-            Assert.assertEquals(aByte, bByte);
+            Assertions.assertEquals(aByte, bByte);
         }
     }
 }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
@@ -17,24 +17,24 @@
 
 package org.apache.commons.imaging.roundtrip;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertNotNull;
-
-@RunWith(Theories.class)
 public class NullParametersRoundtripTest extends RoundtripBase {
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.READ_WRITE_FORMATS;
+    public static Stream<FormatInfo> data() {
+        return Stream.of(FormatInfo.READ_WRITE_FORMATS);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("data")
     public void testNullParametersRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(1, 1);
         final File temp1 = createTempFile("nullParameters.", "." + formatInfo.format.getExtension());

--- a/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
@@ -31,7 +31,7 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(Theories.class)
 public class PixelDensityRoundtrip extends RoundtripBase {
@@ -56,13 +56,9 @@ public class PixelDensityRoundtrip extends RoundtripBase {
             final int xReadDPI = imageInfo.getPhysicalWidthDpi();
             final int yReadDPI = imageInfo.getPhysicalHeightDpi();
             // allow a 5% margin of error in storage and conversion
-            assertTrue("horizontal pixel density stored wrongly for " + formatInfo.format +
-                            " in=" + pixelDensity.horizontalDensityInches() + ", out=" + xReadDPI,
-                    Math.abs((xReadDPI - pixelDensity.horizontalDensityInches()) /
+            assertTrue(Math.abs((xReadDPI - pixelDensity.horizontalDensityInches()) /
                             pixelDensity.horizontalDensityInches()) <= 0.05);
-            assertTrue("vertical pixel density stored wrongly for " + formatInfo.format +
-                            " in=" + pixelDensity.verticalDensityInches() + ", out=" + yReadDPI,
-                    Math.abs((yReadDPI - pixelDensity.verticalDensityInches()) /
+            assertTrue(Math.abs((yReadDPI - pixelDensity.verticalDensityInches()) /
                             pixelDensity.verticalDensityInches()) <= 0.05);
         }
     }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.imaging.roundtrip;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -28,15 +30,12 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.RgbBufferedImageFactory;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.io.TempDir;
 
 public class RoundtripBase {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public File folder;
 
     protected void roundtrip(final FormatInfo formatInfo, final BufferedImage testImage,
                              final String tempPrefix, final boolean imageExact) throws IOException,
@@ -72,7 +71,7 @@ public class RoundtripBase {
 
     protected File createTempFile(final String prefix, final String suffix)
             throws IOException {
-        return File.createTempFile(prefix, suffix, folder.newFolder());
+        return File.createTempFile(prefix, suffix, folder);
     }
 
 }


### PR DESCRIPTION
Used @mureinik 's excellent work on [this PR for Commons CSV](https://github.com/apache/commons-csv/pull/49) for the same end.

Only difference is that Commons Imaging uses Theories (`@Theory`, `@Datapoint`, etc). And this is [not available in JUnit 4](https://github.com/junit-team/junit5/pull/1422#issuecomment-389644868), so I used [JUnit Vintage](https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-vintage) as in [this post](https://www.igorski.co/java/junit/mixing-junit-4-and-junit-5-tests/).