### PR TITLE
IMAGING-242 Complete the migration to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,25 +225,6 @@
       <version>2.1</version>
       <scope>test</scope>
     </dependency>
-    <!-- the next three dependencies are for tests with theories/datapoints, see IMAGING-242 -->
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>1.5.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/src/test/java/org/apache/commons/imaging/TestImageReadException.java
+++ b/src/test/java/org/apache/commons/imaging/TestImageReadException.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/apache/commons/imaging/TestImageWriteException.java
+++ b/src/test/java/org/apache/commons/imaging/TestImageWriteException.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.imaging;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.stream.Stream;
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/BitmapRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/BitmapRoundtripTest.java
@@ -18,16 +18,14 @@
 package org.apache.commons.imaging.roundtrip;
 
 import java.awt.image.BufferedImage;
+import java.util.stream.Stream;
 
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Theories.class)
 public class BitmapRoundtripTest extends RoundtripBase {
 
-    @DataPoints
     public static BufferedImage[] images = new BufferedImage[] {
             TestImages.createArgbBitmapImage(1, 1), // minimal
             TestImages.createArgbBitmapImage(2, 2), //
@@ -40,10 +38,12 @@ public class BitmapRoundtripTest extends RoundtripBase {
             TestImages.createBitmapBitmapImage(300, 300), // larger than 256
     };
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.READ_WRITE_FORMATS;
+    public static Stream<Arguments> testBitmapRoundtrip() {
+        return createRoundtripArguments(images);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource
     public void testBitmapRoundtrip(final BufferedImage testImage, final FormatInfo formatInfo) throws Exception {
         roundtrip(formatInfo, testImage, "bitmap", true);
     }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/FullColorRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/FullColorRoundtrip.java
@@ -18,16 +18,14 @@
 package org.apache.commons.imaging.roundtrip;
 
 import java.awt.image.BufferedImage;
+import java.util.stream.Stream;
 
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Theories.class)
 public class FullColorRoundtrip extends RoundtripBase {
 
-    @DataPoints
     public static BufferedImage[] images = new BufferedImage[]{
             TestImages.createFullColorImage(1, 1), // minimal
             TestImages.createFullColorImage(2, 2), //
@@ -35,10 +33,12 @@ public class FullColorRoundtrip extends RoundtripBase {
             TestImages.createFullColorImage(300, 300), // larger than 256
     };
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.READ_WRITE_FORMATS;
+    public static Stream<Arguments> testFullColorRoundtrip() {
+        return createRoundtripArguments(images);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource
     public void testFullColorRoundtrip(final BufferedImage testImage, final FormatInfo formatInfo) throws Exception {
         boolean imageExact = true;
         if (formatInfo.colorSupport == FormatInfo.COLOR_BITMAP) {

--- a/src/test/java/org/apache/commons/imaging/roundtrip/GrayscaleRountripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/GrayscaleRountripTest.java
@@ -18,16 +18,14 @@
 package org.apache.commons.imaging.roundtrip;
 
 import java.awt.image.BufferedImage;
+import java.util.stream.Stream;
 
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Theories.class)
 public class GrayscaleRountripTest extends RoundtripBase {
 
-    @DataPoints
     public static BufferedImage[] images = new BufferedImage[]{
             TestImages.createArgbBitmapImage(1, 1), // minimal
             TestImages.createArgbGrayscaleImage(2, 2), //
@@ -40,10 +38,12 @@ public class GrayscaleRountripTest extends RoundtripBase {
             TestImages.createGrayscaleGrayscaleImage(300, 300), // larger than 256
     };
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.READ_WRITE_FORMATS;
+    public static Stream<Arguments> testGrayscaleRoundtrip() {
+        return createRoundtripArguments(images);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource
     public void testGrayscaleRoundtrip(final BufferedImage testImage, final FormatInfo formatInfo) throws Exception {
             final boolean imageExact = formatInfo.colorSupport != FormatInfo.COLOR_BITMAP;
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/LimitedColorRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/LimitedColorRoundtripTest.java
@@ -18,16 +18,14 @@
 package org.apache.commons.imaging.roundtrip;
 
 import java.awt.image.BufferedImage;
+import java.util.stream.Stream;
 
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Theories.class)
 public class LimitedColorRoundtripTest extends RoundtripBase {
 
-    @DataPoints
     public static BufferedImage[] images = new BufferedImage[] {
             TestImages.createLimitedColorImage(1, 1), // minimal
             TestImages.createLimitedColorImage(2, 2), //
@@ -35,10 +33,12 @@ public class LimitedColorRoundtripTest extends RoundtripBase {
             TestImages.createLimitedColorImage(300, 300), // larger than 256
     };
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.READ_WRITE_FORMATS;
+    public static Stream<Arguments> testLimitedColorRoundtrip() {
+        return createRoundtripArguments(images);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource
     public void testLimitedColorRoundtrip(final BufferedImage testImage, final FormatInfo formatInfo) throws Exception {
             boolean imageExact = true;
             if (formatInfo.colorSupport == FormatInfo.COLOR_BITMAP) {

--- a/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
@@ -19,27 +19,28 @@ package org.apache.commons.imaging.roundtrip;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.PixelDensity;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Theories.class)
 public class PixelDensityRoundtrip extends RoundtripBase {
 
-    @DataPoints
-    public static FormatInfo[] formatInfos = FormatInfo.PRESERVING_RESOLUTION_FORMATS;
+    public static Stream<FormatInfo> testPixelDensityRoundtrip() {
+        return Arrays.stream(FormatInfo.PRESERVING_RESOLUTION_FORMATS);
+    }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource
     public void testPixelDensityRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(2, 2);
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -21,8 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
@@ -31,6 +33,7 @@ import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.RgbBufferedImageFactory;
 import org.apache.commons.imaging.internal.Debug;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.provider.Arguments;
 
 public class RoundtripBase {
 
@@ -74,4 +77,7 @@ public class RoundtripBase {
         return File.createTempFile(prefix, suffix, folder);
     }
 
+    public static Stream<Arguments> createRoundtripArguments(BufferedImage[] images) {
+        return Arrays.stream(images).flatMap(i -> Arrays.stream(FormatInfo.READ_WRITE_FORMATS).map(f -> Arguments.of(i, f)));
+    }
 }


### PR DESCRIPTION
This PR follows up https://github.com/apache/commons-imaging/pull/59 and completes the migration to JUnit Jupiter:

- Usages of `org.junit.Assert.assert[Not]Null` were replaced with `org.junit.jupiter.api.Assertions.asserrt[Not]Null`.
- Usages of `@Theories` and `@DataPoints` where replaces with JUnit Jupiter's `@ParameterizedTest` with `@MethodSources`. Unfortunately, Jupiter doesn't have a built-in capability to create a Cartesian product of datapoints like `@Theories` does, so this logic had to be explicitly implemented in `RountripBase`.
- With this cleanup, the additional Junit 5 Vintage dependencies could be removed.