### PR TITLE
[IMAGING-155]: cleaning up ImagingTest base class by removing createTempFile method and using the JDK File method instead

### DIFF
--- a/src/test/java/org/apache/commons/imaging/ImagingTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImagingTest.java
@@ -26,17 +26,8 @@ import java.util.List;
 
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.imaging.test.util.FileSystemTraversal;
-import org.junit.jupiter.api.io.TempDir;
 
 public abstract class ImagingTest {
-
-    @TempDir
-    public File folder;
-
-    protected File createTempFile(final String prefix, final String suffix)
-            throws IOException {
-        return File.createTempFile(prefix, suffix, folder);
-    }
 
     protected boolean isPhilHarveyTestImage(final File file) {
         return file.getAbsolutePath().startsWith(

--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ByteSourceTest extends ImagingTest {
     protected File createTempFile(final byte src[]) throws IOException {
-        final File file = createTempFile("raw_", ".bin");
+        final File file = File.createTempFile("raw_", ".bin");
 
         // write test bytes to file.
         try (FileOutputStream fos = new FileOutputStream(file);

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -151,7 +151,7 @@ public class BmpRoundtripTest extends BmpBaseTest {
 
         // Debug.debug("bytes", bytes);
 
-        final File tempFile = createTempFile("temp", ".bmp");
+        final File tempFile = File.createTempFile("temp", ".bmp");
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
@@ -407,7 +407,7 @@ public class IcnsRoundTripTest extends IcnsBaseTest {
     private void writeAndReadImageData(final String description, final byte[] rawData,
             final int foreground, final int background) throws IOException,
             ImageReadException {
-        final File exportFile = createTempFile(description, ".icns");
+        final File exportFile = File.createTempFile(description, ".icns");
         FileUtils.writeByteArrayToFile(exportFile, rawData);
         final BufferedImage dstImage = Imaging.getBufferedImage(exportFile);
 

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
@@ -537,7 +537,7 @@ public class IcoRoundtripTest extends IcoBaseTest {
         // File exportFile = new File("/tmp/" + description + ".ico");
         // IoUtils.writeToFile(rawData, exportFile);
 
-        final File tempFile = createTempFile("temp", ".ico");
+        final File tempFile = File.createTempFile("temp", ".ico");
         FileUtils.writeByteArrayToFile(tempFile, rawData);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(tempFile);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -84,7 +84,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = createTempFile("test", ".jpg");
+                final File tempFile = File.createTempFile("test", ".jpg");
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -124,7 +124,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = createTempFile("removed", ".jpg");
+                final File tempFile = File.createTempFile("removed", ".jpg");
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -145,7 +145,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                         outputSet);
 
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = createTempFile("inserted" + "_", ".jpg");
+                final File tempFile = File.createTempFile("inserted" + "_", ".jpg");
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -214,7 +214,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 rewriter.rewrite(byteSource, baos, outputSet);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = createTempFile(name + "_", ".jpg");
+                final File tempFile = File.createTempFile(name + "_", ".jpg");
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
@@ -46,7 +46,7 @@ public class WriteExifMetadataExampleTest extends ExifBaseTest {
     public void testOddOffsets(File imageFile) throws Exception {
         Debug.debug("imageFile", imageFile.getAbsoluteFile());
 
-        final File tempFile = createTempFile("test", ".jpg");
+        final File tempFile = File.createTempFile("test", ".jpg");
         Debug.debug("tempFile", tempFile.getAbsoluteFile());
 
         try {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
@@ -80,7 +80,7 @@ public class IptcAddTest extends IptcBaseTest {
 
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords, newBlocks);
 
-        final File updated = createTempFile(imageFile.getName() + ".iptc.add.", ".jpg");
+        final File updated = File.createTempFile(imageFile.getName() + ".iptc.add.", ".jpg");
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {
             new JpegIptcRewriter().writeIPTC(byteSource, os, newData);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
@@ -74,7 +74,7 @@ public class IptcUpdateTest extends IptcBaseTest {
     }
 
     public File removeIptc(final ByteSource byteSource, File imageFile) throws Exception {
-        final File noIptcFile = createTempFile(imageFile.getName() + ".iptc.remove.", ".jpg");
+        final File noIptcFile = File.createTempFile(imageFile.getName() + ".iptc.remove.", ".jpg");
 
         try (OutputStream os = new BufferedOutputStream(new FileOutputStream(noIptcFile))) {
             new JpegIptcRewriter().removeIPTC(byteSource, os);
@@ -107,7 +107,7 @@ public class IptcUpdateTest extends IptcBaseTest {
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords,
                 newBlocks);
 
-        final File updated = createTempFile(imageFile.getName()
+        final File updated = File.createTempFile(imageFile.getName()
                 + ".iptc.insert.", ".jpg");
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {
@@ -156,7 +156,7 @@ public class IptcUpdateTest extends IptcBaseTest {
     }
 
     public File writeIptc(final ByteSource byteSource, final PhotoshopApp13Data newData, File imageFile) throws IOException, ImageReadException, ImageWriteException {
-        final File updated = createTempFile(imageFile.getName()
+        final File updated = File.createTempFile(imageFile.getName()
                 + ".iptc.update.", ".jpg");
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
@@ -49,7 +49,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
         final String xmpXml = new JpegImageParser().getXmpXml(byteSource, params);
         assertNotNull(xmpXml);
 
-        final File noXmpFile = createTempFile(imageFile.getName() + ".", ".jpg");
+        final File noXmpFile = File.createTempFile(imageFile.getName() + ".", ".jpg");
         {
             // test remove
 
@@ -70,7 +70,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test update
 
             final String newXmpXml = "test";
-            final File updated = createTempFile(imageFile.getName() + ".", ".jpg");
+            final File updated = File.createTempFile(imageFile.getName() + ".", ".jpg");
             try (FileOutputStream fos = new FileOutputStream(updated);
                     OutputStream os = new BufferedOutputStream(fos)) {
                 new JpegXmpRewriter().updateXmpXml(byteSource, os, newXmpXml);
@@ -89,7 +89,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test insert
 
             final String newXmpXml = "test";
-            final File updated = createTempFile(imageFile.getName() + ".", ".jpg");
+            final File updated = File.createTempFile(imageFile.getName() + ".", ".jpg");
             try (FileOutputStream fos = new FileOutputStream(updated);
                     OutputStream os = new BufferedOutputStream(fos)) {
                 new JpegXmpRewriter().updateXmpXml(new ByteSourceFile(

--- a/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
@@ -52,7 +52,7 @@ public class ConvertPngToGifTest extends PngBaseTest {
             final BufferedImage image = Imaging.getBufferedImage(imageFile, params);
             assertNotNull(image);
 
-            final File outFile = createTempFile(imageFile.getName() + ".", ".gif");
+            final File outFile = File.createTempFile(imageFile.getName() + ".", ".gif");
             // Debug.debug("outFile", outFile);
 
             Imaging.writeImage(image, outFile, ImageFormats.GIF,

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
@@ -62,7 +62,7 @@ public class PngMultipleRoundtripTest extends PngBaseTest {
                         readParams);
                 assertNotNull(image);
 
-                final File tempFile = createTempFile(imageFile.getName() + "." + j
+                final File tempFile = File.createTempFile(imageFile.getName() + "." + j
                         + ".", ".png");
                 Debug.debug("tempFile", tempFile);
 

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
@@ -71,7 +71,7 @@ public class PngTextTest extends PngBaseTest {
         final byte[] bytes = Imaging.writeImageToBytes(srcImage,
                 ImageFormats.PNG, writeParams);
 
-        final File tempFile = createTempFile("temp", ".png");
+        final File tempFile = File.createTempFile("temp", ".png");
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -53,7 +53,7 @@ public class PngWriteForceTrueColorText extends PngBaseTest {
                         new HashMap<String, Object>());
                 assertNotNull(image);
 
-                final File outFile = createTempFile(imageFile.getName() + ".", ".gif");
+                final File outFile = File.createTempFile(imageFile.getName() + ".", ".gif");
                 // Debug.debug("outFile", outFile);
 
                 final Map<String, Object> params = new HashMap<>();

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
@@ -192,7 +192,7 @@ public class PngWriteReadTest extends ImagingTest {
 
         // Debug.debug("bytes", bytes);
 
-        final File tempFile = createTempFile("temp", ".png");
+        final File tempFile = File.createTempFile("temp", ".png");
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
@@ -221,7 +221,7 @@ public class PngWriteReadTest extends ImagingTest {
 
         // Debug.debug("bytes", bytes);
 
-        final File tempFile = createTempFile("temp", ".png");
+        final File tempFile = File.createTempFile("temp", ".png");
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
@@ -59,7 +59,7 @@ public class TiffRoundtripTest extends TiffBaseTest {
                     TiffConstants.TIFF_COMPRESSION_DEFLATE_ADOBE
             };
             for (final int compression : compressions) {
-                final File tempFile = createTempFile(imageFile.getName() + "-" + compression + ".", ".tif");
+                final File tempFile = File.createTempFile(imageFile.getName() + "-" + compression + ".", ".tif");
                 final Map<String, Object> params = new HashMap<>();
                 params.put(ImagingConstants.PARAM_KEY_COMPRESSION, compression);
                 Imaging.writeImage(image, tempFile, ImageFormats.TIFF,

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
@@ -77,7 +77,7 @@ public class XmpUpdateTest extends ImagingTest {
                 continue;
             }
 
-            final File tempFile = this.createTempFile(imageFile.getName() + ".", "."
+            final File tempFile = File.createTempFile(imageFile.getName() + ".", "."
                     + imageFormat.getExtension());
             final BufferedImage image = Imaging.getBufferedImage(imageFile);
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
@@ -37,7 +37,7 @@ public class NullParametersRoundtripTest extends RoundtripBase {
     @MethodSource("data")
     public void testNullParametersRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(1, 1);
-        final File temp1 = createTempFile("nullParameters.", "." + formatInfo.format.getExtension());
+        final File temp1 = File.createTempFile("nullParameters.", "." + formatInfo.format.getExtension());
         Imaging.writeImage(testImage, temp1, formatInfo.format, null);
         Imaging.getImageInfo(temp1, null);
         Imaging.getImageSize(temp1, null);

--- a/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
@@ -44,7 +44,7 @@ public class PixelDensityRoundtrip extends RoundtripBase {
     public void testPixelDensityRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(2, 2);
 
-        final File temp1 = createTempFile("pixeldensity.", "."
+        final File temp1 = File.createTempFile("pixeldensity.", "."
                 + formatInfo.format.getExtension());
 
         final Map<String, Object> params = new HashMap<>();

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -32,18 +32,14 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.common.RgbBufferedImageFactory;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class RoundtripBase {
 
-    @TempDir
-    public File folder;
-
     protected void roundtrip(final FormatInfo formatInfo, final BufferedImage testImage,
                              final String tempPrefix, final boolean imageExact) throws IOException,
             ImageReadException, ImageWriteException {
-        final File temp1 = createTempFile(tempPrefix + ".", "."
+        final File temp1 = File.createTempFile(tempPrefix + ".", "."
                 + formatInfo.format.getExtension());
         Debug.debug("tempFile: " + temp1.getName());
 
@@ -63,18 +59,13 @@ public class RoundtripBase {
         }
 
         if (formatInfo.identicalSecondWrite) {
-            final File temp2 = createTempFile(tempPrefix + ".", "."
+            final File temp2 = File.createTempFile(tempPrefix + ".", "."
                     + formatInfo.format.getExtension());
             // Debug.debug("tempFile: " + tempFile.getName());
             Imaging.writeImage(image2, temp2, formatInfo.format, params);
 
             ImageAsserts.assertEquals(temp1, temp2);
         }
-    }
-
-    protected File createTempFile(final String prefix, final String suffix)
-            throws IOException {
-        return File.createTempFile(prefix, suffix, folder);
     }
 
     public static Stream<Arguments> createRoundtripArguments(BufferedImage[] images) {


### PR DESCRIPTION
As per title, the `ImagingTest` base class has most of the logic that is handling to traverse directories and load files, which is part of the problem described in IMAGING-155.

This PR does not close IMAGING-155, but starts by removing the method `createTempFile` that also uses an instance `File` annotated by Junit's `TempDir` as base directory - turns out this directory is not really necessary as we only use the `File` created per method.

There was also a similar method in `RoundTripBase` that was also removed in favor of the JDK's method.

Further pull requests will keep tidying `ImagingTest`.

Bruno