### PR TITLE
IMAGING-151: use a copy of the list, make members package-protected/private, and re-use Comparator

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,9 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="IMAGING-244" dev="kinow" type="add">
         Use isEmpty instead of comparing size() with integers
       </action>
+      <action issue="IMAGING-151" dev="kinow" type="fix">
+        ColorGroup.color_counts is mutable public List and is multiply sorted
+      </action>
       <action issue="IMAGING-243" dev="kinow" type="add" due-to="Andreas Menze">
         PNG Writer Indexed Color with semi-transparent Pixels and Better Compression
       </action>

--- a/src/main/java/org/apache/commons/imaging/palette/ColorComponent.java
+++ b/src/main/java/org/apache/commons/imaging/palette/ColorComponent.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.imaging.palette;
 
+/**
+ * An RGBA (reg, green, blue, alpha) color space component enum.
+ *
+ * @since 1.0-alpha1
+ */
 enum ColorComponent {
     ALPHA(24),
     RED(16),

--- a/src/main/java/org/apache/commons/imaging/palette/ColorCountComparator.java
+++ b/src/main/java/org/apache/commons/imaging/palette/ColorCountComparator.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.palette;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * A comparator for {#link ColorCount} elements.
+ *
+ * <p>It uses a given {#link ColorComponent} to choose what
+ * channel must be used for the comparison.</p>
+ *
+ * <p>For example, if the comparator is created for the
+ * {@code ColorComponent.RED} channel, then it will
+ * compare the value of red of each {@code ColorCount}
+ * object in the array of elements.</p>
+ *
+ * @since 1.0-alpha2
+ */
+public class ColorCountComparator implements Comparator<ColorCount>, Serializable {
+    private static final long serialVersionUID = 1L;
+    /**
+     * Color component used during the comparison.
+     */
+    private ColorComponent colorComponent;
+
+    public ColorCountComparator(final ColorComponent colorComponent) {
+        this.colorComponent = colorComponent;
+    }
+
+    @Override
+    public int compare(ColorCount c1, ColorCount c2) {
+        switch (colorComponent) {
+        case ALPHA:
+            return c1.alpha - c2.alpha;
+        case RED:
+            return c1.red - c2.red;
+        case GREEN:
+            return c1.green - c2.green;
+        case BLUE:
+            return c1.blue - c2.blue;
+        default:
+            return 0;
+        }
+    }
+
+}

--- a/src/main/java/org/apache/commons/imaging/palette/ColorGroup.java
+++ b/src/main/java/org/apache/commons/imaging/palette/ColorGroup.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.palette;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.imaging.ImageWriteException;
@@ -26,7 +27,7 @@ class ColorGroup {
     // final List children = new ArrayList();
     int paletteIndex = -1;
 
-    final List<ColorCount> colorCounts;
+    private final List<ColorCount> colorCounts;
     final boolean ignoreAlpha;
     int minRed = Integer.MAX_VALUE;
     int maxRed = Integer.MIN_VALUE;
@@ -121,6 +122,14 @@ class ColorGroup {
         final int blue = (int) Math.round((double) blueTotal / countTotal);
 
         return (alpha << 24) | (red << 16) | (green << 8) | blue;
+    }
+
+    /**
+     * Return a copy of the list of color counts.
+     * @return a copy of the list of color counts
+     */
+    List<ColorCount> getColorCounts() {
+        return new ArrayList<ColorCount>(colorCounts);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/palette/ColorGroup.java
+++ b/src/main/java/org/apache/commons/imaging/palette/ColorGroup.java
@@ -21,30 +21,30 @@ import java.util.List;
 import org.apache.commons.imaging.ImageWriteException;
 
 class ColorGroup {
-    // public final ColorGroup parent;
-    public ColorGroupCut cut;
-    // public final List children = new ArrayList();
-    public int paletteIndex = -1;
+    // final ColorGroup parent;
+    ColorGroupCut cut;
+    // final List children = new ArrayList();
+    int paletteIndex = -1;
 
-    public final List<ColorCount> colorCounts;
-    public final boolean ignoreAlpha;
-    public int minRed = Integer.MAX_VALUE;
-    public int maxRed = Integer.MIN_VALUE;
-    public int minGreen = Integer.MAX_VALUE;
-    public int maxGreen = Integer.MIN_VALUE;
-    public int minBlue = Integer.MAX_VALUE;
-    public int maxBlue = Integer.MIN_VALUE;
-    public int minAlpha = Integer.MAX_VALUE;
-    public int maxAlpha = Integer.MIN_VALUE;
+    final List<ColorCount> colorCounts;
+    final boolean ignoreAlpha;
+    int minRed = Integer.MAX_VALUE;
+    int maxRed = Integer.MIN_VALUE;
+    int minGreen = Integer.MAX_VALUE;
+    int maxGreen = Integer.MIN_VALUE;
+    int minBlue = Integer.MAX_VALUE;
+    int maxBlue = Integer.MIN_VALUE;
+    int minAlpha = Integer.MAX_VALUE;
+    int maxAlpha = Integer.MIN_VALUE;
 
-    public final int alphaDiff;
-    public final int redDiff;
-    public final int greenDiff;
-    public final int blueDiff;
+    final int alphaDiff;
+    final int redDiff;
+    final int greenDiff;
+    final int blueDiff;
 
-    public final int maxDiff;
-    public final int diffTotal;
-    public final int totalPoints;
+    final int maxDiff;
+    final int diffTotal;
+    final int totalPoints;
 
     ColorGroup(final List<ColorCount> colorCounts, final boolean ignoreAlpha) throws ImageWriteException {
         this.colorCounts = colorCounts;
@@ -79,7 +79,7 @@ class ColorGroup {
         diffTotal = (ignoreAlpha ? 0 : alphaDiff) + redDiff + greenDiff + blueDiff;
     }
 
-    public boolean contains(final int argb) {
+    boolean contains(final int argb) {
         final int alpha = 0xff & (argb >> 24);
         final int red = 0xff & (argb >> 16);
         final int green = 0xff & (argb >> 8);
@@ -100,7 +100,7 @@ class ColorGroup {
         return true;
     }
 
-    public int getMedianValue() {
+    int getMedianValue() {
         long countTotal = 0;
         long alphaTotal = 0;
         long redTotal = 0;

--- a/src/main/java/org/apache/commons/imaging/palette/LongestAxisMedianCut.java
+++ b/src/main/java/org/apache/commons/imaging/palette/LongestAxisMedianCut.java
@@ -74,13 +74,14 @@ public class LongestAxisMedianCut implements MedianCut {
             }
         };
 
-        Collections.sort(colorGroup.colorCounts, comp);
+        final List<ColorCount> colorCounts = colorGroup.getColorCounts();
+        Collections.sort(colorCounts, comp);
         final int countHalf = (int) Math.round((double) colorGroup.totalPoints / 2);
         int oldCount = 0;
         int newCount = 0;
         int medianIndex;
-        for (medianIndex = 0; medianIndex < colorGroup.colorCounts.size(); medianIndex++) {
-            final ColorCount colorCount = colorGroup.colorCounts.get(medianIndex);
+        for (medianIndex = 0; medianIndex < colorCounts.size(); medianIndex++) {
+            final ColorCount colorCount = colorCounts.get(medianIndex);
 
             newCount += colorCount.count;
 
@@ -91,7 +92,7 @@ public class LongestAxisMedianCut implements MedianCut {
             }
         }
 
-        if (medianIndex == colorGroup.colorCounts.size() - 1) {
+        if (medianIndex == colorCounts.size() - 1) {
             medianIndex--;
         } else if (medianIndex > 0) {
             final int newDiff = Math.abs(newCount - countHalf);
@@ -103,17 +104,17 @@ public class LongestAxisMedianCut implements MedianCut {
 
         colorGroups.remove(colorGroup);
         final List<ColorCount> colorCounts1 = new ArrayList<>(
-                colorGroup.colorCounts.subList(0, medianIndex + 1));
+                colorCounts.subList(0, medianIndex + 1));
         final List<ColorCount> colorCounts2 = new ArrayList<>(
-                colorGroup.colorCounts.subList(medianIndex + 1,
-                        colorGroup.colorCounts.size()));
+                colorCounts.subList(medianIndex + 1,
+                        colorCounts.size()));
 
         final ColorGroup less = new ColorGroup(new ArrayList<>(colorCounts1), ignoreAlpha);
         colorGroups.add(less);
         final ColorGroup more = new ColorGroup(new ArrayList<>(colorCounts2), ignoreAlpha);
         colorGroups.add(more);
 
-        final ColorCount medianValue = colorGroup.colorCounts.get(medianIndex);
+        final ColorCount medianValue = colorCounts.get(medianIndex);
         int limit;
         switch (mode) {
             case ALPHA:

--- a/src/main/java/org/apache/commons/imaging/palette/LongestAxisMedianCut.java
+++ b/src/main/java/org/apache/commons/imaging/palette/LongestAxisMedianCut.java
@@ -59,23 +59,8 @@ public class LongestAxisMedianCut implements MedianCut {
     private void doCut(final ColorGroup colorGroup, final ColorComponent mode,
             final List<ColorGroup> colorGroups, final boolean ignoreAlpha) throws ImageWriteException {
 
-        final Comparator<ColorCount> comp = (c1, c2) -> {
-            switch (mode) {
-                case ALPHA:
-                    return c1.alpha - c2.alpha;
-                case RED:
-                    return c1.red - c2.red;
-                case GREEN:
-                    return c1.green - c2.green;
-                case BLUE:
-                    return c1.blue - c2.blue;
-                default:
-                    return 0;
-            }
-        };
-
         final List<ColorCount> colorCounts = colorGroup.getColorCounts();
-        Collections.sort(colorCounts, comp);
+        Collections.sort(colorCounts, new ColorCountComparator(mode));
         final int countHalf = (int) Math.round((double) colorGroup.totalPoints / 2);
         int oldCount = 0;
         int newCount = 0;

--- a/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
+++ b/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
@@ -130,7 +130,7 @@ public class MedianCutQuantizer {
 
             colorGroup.paletteIndex = i;
 
-            if (colorGroup.colorCounts.isEmpty()) {
+            if (colorGroup.getColorCounts().isEmpty()) {
                 throw new ImageWriteException("empty color_group: "
                         + colorGroup);
             }

--- a/src/main/java/org/apache/commons/imaging/palette/MostPopulatedBoxesMedianCut.java
+++ b/src/main/java/org/apache/commons/imaging/palette/MostPopulatedBoxesMedianCut.java
@@ -16,10 +16,8 @@
  */
 package org.apache.commons.imaging.palette;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.imaging.ImageWriteException;
@@ -52,7 +50,7 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             if (ignoreAlpha && colorComponent == ColorComponent.ALPHA) {
                 continue;
             }
-            Collections.sort(colorCounts, new ColorComparer(colorComponent));
+            Collections.sort(colorCounts, new ColorCountComparator(colorComponent));
             final int countHalf = (int) Math.round((double) colorGroup.totalPoints / 2);
             int oldCount = 0;
             int newCount = 0;
@@ -101,7 +99,7 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             return false;
         }
 
-        Collections.sort(colorCounts, new ColorComparer(bestColorComponent));
+        Collections.sort(colorCounts, new ColorCountComparator(bestColorComponent));
         final List<ColorCount> lowerColors = new ArrayList<>(
                 colorCounts.subList(0, bestMedianIndex + 1));
         final List<ColorCount> upperColors = new ArrayList<>(
@@ -134,31 +132,4 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
         colorGroup.cut = new ColorGroupCut(lowerGroup, upperGroup, bestColorComponent, limit);
         return true;
     }
-
-    private static class ColorComparer implements Comparator<ColorCount>, Serializable {
-        private static final long serialVersionUID = 1L;
-
-        private final ColorComponent colorComponent;
-
-        ColorComparer(final ColorComponent colorComponent) {
-            this.colorComponent = colorComponent;
-        }
-
-        @Override
-        public int compare(final ColorCount c1, final ColorCount c2) {
-            switch (colorComponent) {
-                case ALPHA:
-                    return c1.alpha - c2.alpha;
-                case RED:
-                    return c1.red - c2.red;
-                case GREEN:
-                    return c1.green - c2.green;
-                case BLUE:
-                    return c1.blue - c2.blue;
-                default:
-                    return 0;
-            }
-        }
-    }
-
 }

--- a/src/main/java/org/apache/commons/imaging/palette/MostPopulatedBoxesMedianCut.java
+++ b/src/main/java/org/apache/commons/imaging/palette/MostPopulatedBoxesMedianCut.java
@@ -43,7 +43,7 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             return false;
         }
 
-
+        final List<ColorCount> colorCounts = colorGroup.getColorCounts();
 
         double bestScore = Double.MAX_VALUE;
         ColorComponent bestColorComponent = null;
@@ -52,13 +52,13 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             if (ignoreAlpha && colorComponent == ColorComponent.ALPHA) {
                 continue;
             }
-            Collections.sort(colorGroup.colorCounts, new ColorComparer(colorComponent));
+            Collections.sort(colorCounts, new ColorComparer(colorComponent));
             final int countHalf = (int) Math.round((double) colorGroup.totalPoints / 2);
             int oldCount = 0;
             int newCount = 0;
             int medianIndex;
-            for (medianIndex = 0; medianIndex < colorGroup.colorCounts.size(); medianIndex++) {
-                final ColorCount colorCount = colorGroup.colorCounts.get(medianIndex);
+            for (medianIndex = 0; medianIndex < colorCounts.size(); medianIndex++) {
+                final ColorCount colorCount = colorCounts.get(medianIndex);
 
                 newCount += colorCount.count;
 
@@ -68,7 +68,7 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
                     break;
                 }
             }
-            if (medianIndex == colorGroup.colorCounts.size() - 1) {
+            if (medianIndex == colorCounts.size() - 1) {
                 medianIndex--;
             } else if (medianIndex > 0) {
                 final int newDiff = Math.abs(newCount - countHalf);
@@ -79,10 +79,10 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             }
 
             final List<ColorCount> lowerColors = new ArrayList<>(
-                    colorGroup.colorCounts.subList(0, medianIndex + 1));
+                    colorCounts.subList(0, medianIndex + 1));
             final List<ColorCount> upperColors = new ArrayList<>(
-                    colorGroup.colorCounts.subList(medianIndex + 1,
-                            colorGroup.colorCounts.size()));
+                    colorCounts.subList(medianIndex + 1,
+                            colorCounts.size()));
             if (lowerColors.isEmpty() || upperColors.isEmpty()) {
                 continue;
             }
@@ -101,19 +101,19 @@ public class MostPopulatedBoxesMedianCut implements MedianCut {
             return false;
         }
 
-        Collections.sort(colorGroup.colorCounts, new ColorComparer(bestColorComponent));
+        Collections.sort(colorCounts, new ColorComparer(bestColorComponent));
         final List<ColorCount> lowerColors = new ArrayList<>(
-                colorGroup.colorCounts.subList(0, bestMedianIndex + 1));
+                colorCounts.subList(0, bestMedianIndex + 1));
         final List<ColorCount> upperColors = new ArrayList<>(
-                colorGroup.colorCounts.subList(bestMedianIndex + 1,
-                        colorGroup.colorCounts.size()));
+                colorCounts.subList(bestMedianIndex + 1,
+                        colorCounts.size()));
         final ColorGroup lowerGroup = new ColorGroup(lowerColors, ignoreAlpha);
         final ColorGroup upperGroup = new ColorGroup(upperColors, ignoreAlpha);
         colorGroups.remove(colorGroup);
         colorGroups.add(lowerGroup);
         colorGroups.add(upperGroup);
 
-        final ColorCount medianValue = colorGroup.colorCounts.get(bestMedianIndex);
+        final ColorCount medianValue = colorCounts.get(bestMedianIndex);
         int limit;
         switch (bestColorComponent) {
             case ALPHA:


### PR DESCRIPTION
This PR creates a `Comparator` for `ColorCount`, replacing two comparators created in different parts of the code with the same logic.

The list that was sorted was a member of a class that could be used elsewhere. So instead of altering the values in that list, now other classes need to access that list through a method that returns a copy of the list.

Members in the package-protected class were made package-protected (from public) or private.

Bruno