### PR TITLE
[IMAGING-249]: Make IPTCBlock members private and add getter/setter

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,9 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
     <release version="1.0-alpha2" date="2020-??-??" description="Second 1.0 alpha release">
+      <action issue="IMAGING-249" dev="kinow" type="update">
+        Make IPTCBlock members private and add getter/setter
+      </action>
       <action issue="IMAGING-248" dev="kinow" type="add" due-to="Greg Shrago">
         ICNS: missing element types; some safety checks
       </action>

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcBlock.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcBlock.java
@@ -16,22 +16,38 @@
  */
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
+import java.util.Objects;
+
 /**
  * Represents an IPTC block, a set of key-value pairs of Photoshop IPTC data.
  */
 public class IptcBlock {
     // N.B. The class is used in public API parameter types
 
-    public final int blockType;
-    //  Only currently used by classes in the package
-    final byte[] blockNameBytes; // TODO make private and provide getter?
-    final byte[] blockData; // TODO make private and provide getter?
+    private final int blockType;
+    private final byte[] blockNameBytes;
+    private final byte[] blockData;
 
     public IptcBlock(final int blockType, final byte[] blockNameBytes, final byte[] blockData) {
+        Objects.requireNonNull(blockNameBytes, "Block name bytes must not be null.");
+        Objects.requireNonNull(blockNameBytes, "Block data bytes must not be null.");
         this.blockData = blockData;
         this.blockNameBytes = blockNameBytes;
         this.blockType = blockType;
     }
+
+    public int getBlockType() {
+        return blockType;
+    }
+
+    public byte[] getBlockNameBytes() {
+        return blockNameBytes.clone();
+    }
+
+    public byte[] getBlockData() {
+        return blockData.clone();
+    }
+
 
     public boolean isIPTCBlock() {
         return blockType == IptcConstants.IMAGE_RESOURCE_BLOCK_IPTC_DATA;

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -136,7 +136,7 @@ public class IptcParser extends BinaryFileParser {
                 continue;
             }
 
-            records.addAll(parseIPTCBlock(block.blockData));
+            records.addAll(parseIPTCBlock(block.getBlockData()));
         }
 
         return new PhotoshopApp13Data(records, blocks);
@@ -374,31 +374,30 @@ public class IptcParser extends BinaryFileParser {
         for (final IptcBlock block : blocks) {
             bos.write4Bytes(JpegConstants.CONST_8BIM);
 
-            if (block.blockType < 0 || block.blockType > 0xffff) {
+            if (block.getBlockType() < 0 || block.getBlockType() > 0xffff) {
                 throw new ImageWriteException("Invalid IPTC block type.");
             }
-            bos.write2Bytes(block.blockType);
+            bos.write2Bytes(block.getBlockType());
 
-            if (block.blockNameBytes.length > 255) {
-                throw new ImageWriteException("IPTC block name is too long: "
-                        + block.blockNameBytes.length);
+            final byte[] blockNameBytes = block.getBlockNameBytes();
+            if (blockNameBytes.length > 255) {
+                throw new ImageWriteException("IPTC block name is too long: " + blockNameBytes.length);
             }
-            bos.write(block.blockNameBytes.length);
-            bos.write(block.blockNameBytes);
-            if (block.blockNameBytes.length % 2 == 0) {
+            bos.write(blockNameBytes.length);
+            bos.write(blockNameBytes);
+            if (blockNameBytes.length % 2 == 0) {
                 bos.write(0); // pad to even size, including length byte.
             }
 
-            if (block.blockData.length > IptcConstants.IPTC_NON_EXTENDED_RECORD_MAXIMUM_SIZE) {
-                throw new ImageWriteException("IPTC block data is too long: "
-                        + block.blockData.length);
+            final byte[] blockData = block.getBlockData();
+            if (blockData.length > IptcConstants.IPTC_NON_EXTENDED_RECORD_MAXIMUM_SIZE) {
+                throw new ImageWriteException("IPTC block data is too long: " + blockData.length);
             }
-            bos.write4Bytes(block.blockData.length);
-            bos.write(block.blockData);
-            if (block.blockData.length % 2 == 1) {
+            bos.write4Bytes(blockData.length);
+            bos.write(blockData);
+            if (blockData.length % 2 == 1) {
                 bos.write(0); // pad to even size
             }
-
         }
 
         bos.flush();

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
@@ -71,16 +71,16 @@ public class IptcParserTest {
         final List<IptcBlock> blocks = photoshopApp13Data.getRawBlocks();
         assertEquals(2, blocks.size());
         for (IptcBlock block : blocks) {
-            if (block.blockType == 1028) {
+            if (block.getBlockType() == 1028) {
                 // 0x0404 IPTC-NAA record
-                byte[] data = block.blockData;
+                byte[] data = block.getBlockData();
                 assertTrue(data.length > 0);
-            } else if (block.blockType == 1061) {
+            } else if (block.getBlockType() == 1061) {
                 // 0x0425 (Photoshop 7.0) Caption digest
-                byte[] data = block.blockData;
+                byte[] data = block.getBlockData();
                 assertTrue(data.length > 0);
             } else {
-                fail("Unexpected block type found: " + block.blockType);
+                fail("Unexpected block type found: " + block.getBlockType());
             }
         }
     }


### PR DESCRIPTION
Fixes two TODO's added some time ago when we had a 1.0 release vote. Simply makes `IptcBlock` members private and adds getters and setters. 