### PR TITLE
[IMAGING-263] Fix for raster subset access

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderTiled.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderTiled.java
@@ -324,17 +324,14 @@ public final class DataReaderTiled extends ImageDataReader {
 
         final int nColumnsOfTiles = (width + tileWidth - 1) / tileWidth;
 
-        final int x0 = col0 * tileWidth;
-        final int y0 = row0 * tileLength;
-
         for (int iRow = row0; iRow <= row1; iRow++) {
             for (int iCol = col0; iCol <= col1; iCol++) {
                 final int tile = iRow * nColumnsOfTiles + iCol;
                 final byte[] compressed = imageData.tiles[tile].getData();
                 final byte[] decompressed = decompress(compressed, compression,
                     bytesPerTile, tileWidth, tileLength);
-                int x = iCol * tileWidth - x0;
-                int y = iRow * tileLength - y0;
+                int x = iCol * tileWidth;
+                int y = iRow * tileLength;
                 int[] blockData = unpackFloatingPointSamples(
                     tileWidth, tileLength, tileWidth,
                     decompressed,

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
@@ -122,7 +122,7 @@ public class TiffFloatingPointReadTest {
     }
 
     @Test
-     public void test() {
+    public void test() {
         Map<String, Object> params = new HashMap<>();
         // These TIFF sample data includes files that contain known
         // floating-point values in various formats.  We know the range

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
@@ -174,6 +174,8 @@ public class TiffFloatingPointReadTest {
                 checkSubImage(target, fullRaster, i+1, i, 8, 8);
             }
 
+            // now read the entire image
+            checkSubImage(target, fullRaster, 0, 0, width, height);
 
             // Test the USGS overview file ------------------------------
             // We know from inspection that this sample file contains values
@@ -210,6 +212,9 @@ public class TiffFloatingPointReadTest {
             for(int i=0; i<height-8; i++){
                 checkSubImage(target, fullRaster, i, i, 8, 8);
             }
+            
+            // now read the entire image
+            checkSubImage(target, fullRaster, 0, 0, width, height);
         } catch (ImageReadException | IOException ex) {
             fail("Exception during test " + ex.getMessage());
         }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffFloatingPointReadTest.java
@@ -122,9 +122,8 @@ public class TiffFloatingPointReadTest {
     }
 
     @Test
-    public void test() {
+     public void test() {
         Map<String, Object> params = new HashMap<>();
-
         // These TIFF sample data includes files that contain known
         // floating-point values in various formats.  We know the range
         // of values from inspection using separate utilies. This
@@ -134,6 +133,7 @@ public class TiffFloatingPointReadTest {
         // code in the tabulation.  If you have a file that does not
         // define a no-data value, just use Float.NaN for testing purposes.
         try {
+            // Test the satellite-derived cloud imagery file -----------------------------
             // We know from inspection that this sample file contains values
             // in the range 0 to 1 and uses 9999 as a "no-data" value.
             File target = getTiffFile("Sample64BitFloatingPointPix451x337.tiff");
@@ -143,34 +143,43 @@ public class TiffFloatingPointReadTest {
             }
             float minVal = pInterp.getMinFound();
             float maxVal = pInterp.getMaxFound();
-
             boolean testCondition = 0.0 <= minVal && minVal <= 1.0 && 0.0 <= maxVal && maxVal <= 1.0;
             assertTrue(testCondition, "Min,Max values not in range 0 to 1: " + minVal + ", " + maxVal);
             assertTrue(minVal <= maxVal, "Min Value not <= maxVal: " + minVal + ", " + maxVal);
 
             // To test the sub-image logic, read the full raster and then
-            // the sub-raster.  Compare the results.  The offsets of
-            // 17 are just an arbitrary value not likely to align with
-            // any arbitrary features in the TIFF files.
-            params.clear();
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_X, 17);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_Y, 17);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_WIDTH, 200);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_HEIGHT, 200);
+            // the sub-raster.  Compare the results.  We know from inspection
+            // that the source file is organized using strips of 2 rows each.
+            // The source file is of dimensions 451x337.
+            // The dimensions of the sub-image are arbitrary
             TiffRasterData fullRaster = readRasterFromTIFF(target, null);
-            TiffRasterData partRaster = readRasterFromTIFF(target, params);
-            assertEquals(200, partRaster.getWidth(), "Invalid width in partial for " + target.getName());
-            assertEquals(200, partRaster.getHeight(), "Invalid height in partial for " + target.getName());
-            for (int y = 17; y < 217; y++) {
-                for (int x = 17; x < 217; x++) {
-                    float vFull = fullRaster.getValue(x, y);
-                    float vPart = partRaster.getValue(x - 17, y - 17);
-                    assertEquals(vFull, vPart, "Invalid value match for partial at (" + x + "," + y + ")");
-                }
+            int height = fullRaster.getHeight();
+            int width  = fullRaster.getWidth();
+            // checks based on the 2-rows per strip model
+            checkSubImage(target, fullRaster, 17, 17, 200, 200);
+            checkSubImage(target, fullRaster, 1, 3, width-2, 1);
+            checkSubImage(target, fullRaster, 1, 3, width-2, 3);
+            checkSubImage(target, fullRaster, 1, 4, width-2, 1);
+            checkSubImage(target, fullRaster, 1, 4, width-2, 3);
+            // check the 4 edges
+            checkSubImage(target, fullRaster, 0, 0, width, 1);         // bottom row
+            checkSubImage(target, fullRaster, 0, 0, 1, height);        // left column
+            checkSubImage(target, fullRaster, 0, height-1, width, 1);  // top row
+            checkSubImage(target, fullRaster, width-1, 0, 1, height);  // right column
+
+            // test along the main diagnonal and a parallel that reaches the top-right corner
+            int s = width-height;
+            for(int i=0; i<height-8; i++){
+                checkSubImage(target, fullRaster, i, i, 8, 8);
+                checkSubImage(target, fullRaster, i+1, i, 8, 8);
             }
 
+
+            // Test the USGS overview file ------------------------------
             // We know from inspection that this sample file contains values
             // in the range -2 to 62 and uses -99999 as a "no-data" value.
+            // The file is organized using tiles of size 128-by-128.
+            // and that the overall image size is 338-by-338.
             target = getTiffFile("USGS_13_n38w077_dir5.tiff");
             pInterp = readAndInterpretTIFF(target, -2f, 62f, -99999f);
             if (pInterp == null) {
@@ -182,24 +191,49 @@ public class TiffFloatingPointReadTest {
             assertTrue(testCondition, "Min,Max values not in range -2 to 62: " + minVal + ", " + maxVal);
             assertTrue(minVal <= maxVal, "Min Value not <= maxVal: " + minVal + ", " + maxVal);
 
-            params.clear();
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_X, 17);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_Y, 17);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_WIDTH, 200);
-            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_HEIGHT, 200);
             fullRaster = readRasterFromTIFF(target, null);
-            partRaster = readRasterFromTIFF(target, params);
-            assertEquals(200, partRaster.getWidth(), "Invalid width in partial for " + target.getName());
-            assertEquals(200, partRaster.getHeight(), "Invalid height in partial for " + target.getName());
-            for (int y = 17; y < 217; y++) {
-                for (int x = 17; x < 217; x++) {
+            // The tile size for this file is 128-by-128. The following tests
+            // read subsections starting right before the tile transition and right after it.
+            height = fullRaster.getHeight();
+            width  = fullRaster.getWidth();
+            // checks based on the 128-by-128 tile model
+            checkSubImage(target, fullRaster, 126, 126, 132, 132);
+            checkSubImage(target, fullRaster, 128, 128, 128, 128);
+            checkSubImage(target, fullRaster, 1, 1, width-2, height-2);
+            // check the 4 edges
+            checkSubImage(target, fullRaster, 0, 0, width, 1);         // bottom row
+            checkSubImage(target, fullRaster, 0, 0, 1, height);        // left column
+            checkSubImage(target, fullRaster, 0, height-1, width, 1);  // top row
+            checkSubImage(target, fullRaster, width-1, 0, 1, height);  // right column
+
+            // now test along the main diagonal
+            for(int i=0; i<height-8; i++){
+                checkSubImage(target, fullRaster, i, i, 8, 8);
+            }
+        } catch (ImageReadException | IOException ex) {
+            fail("Exception during test " + ex.getMessage());
+        }
+    }
+
+
+    private void checkSubImage(File target, TiffRasterData fullRaster, int x0, int y0, int width, int height){
+        try{
+            Map<String, Object> params = new HashMap<>();
+            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_X, x0);
+            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_Y, y0);
+            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_WIDTH, width);
+            params.put(TiffConstants.PARAM_KEY_SUBIMAGE_HEIGHT, height);
+            TiffRasterData partRaster = readRasterFromTIFF(target, params);
+            assertEquals(width, partRaster.getWidth(), "Invalid width in partial for " + target.getName());
+            assertEquals(height, partRaster.getHeight(), "Invalid height in partial for " + target.getName());
+            for (int y = y0; y < y0+height; y++) {
+                for (int x = x0; x < x0+width; x++) {
                     float vFull = fullRaster.getValue(x, y);
-                    float vPart = partRaster.getValue(x - 17, y - 17);
-                    assertEquals(vFull, vPart, "Invalid value match for partial at (" + x + "," + y + ")");
+                    float vPart = partRaster.getValue(x - x0, y - y0);
+                    assertEquals(vFull, vPart, "Invalid value match for partial at (" + x + "," + y + ") for "+target.getName());
                 }
             }
-
-        } catch (ImageReadException | IOException ex) {
+        }catch (ImageReadException | IOException ex) {
             fail("Exception during test " + ex.getMessage());
         }
     }


### PR DESCRIPTION
To my embarrassment, I discovered a bug in the indexing logic for reading a partial raster from a floating-point raster data set.  This patch addresses the problem. To avoid future mistakes, I have extended the unit test for partial read operations.

In the differences below, you will see sections in the TiffFloatingPointReadTest.java class where blocks of code have been removed. These were consolidated and transferred into  the checkSubImage() method in order to support the increased number of geometries tested by the code.