### PR TITLE
[IMAGING-269] Consolidate redundant methods in TIFF datareaders

### DIFF
--- a/src/main/java/org/apache/commons/imaging/common/ImageBuilder.java
+++ b/src/main/java/org/apache/commons/imaging/common/ImageBuilder.java
@@ -131,6 +131,56 @@ public class ImageBuilder {
         return makeBufferedImage(data, width, height, hasAlpha);
     }
 
+
+     /**
+     * Gets a subset of the ImageBuilder content using the specified parameters
+     * to indicate an area of interest. If the parameters specify a rectangular
+     * region that is not entirely contained within the bounds defined
+     * by the ImageBuilder, this method will throw a RasterFormatException.
+     * This run- time exception is consistent with the behavior of the
+     * getSubimage method provided by BufferedImage.
+     * @param x the X coordinate of the upper-left corner of the
+     *          specified rectangular region
+     * @param y the Y coordinate of the upper-left corner of the
+     *          specified rectangular region
+     * @param w the width of the specified rectangular region
+     * @param h the height of the specified rectangular region
+     * @return a valid instance of the specified width and height.
+     * @throws RasterFormatException if the specified area is not contained
+     *         within this ImageBuilder
+     */
+    public ImageBuilder getSubset(final int x, final int y, final int w, final int h) {
+        if (w <= 0) {
+            throw new RasterFormatException("negative or zero subimage width");
+        }
+        if (h <= 0) {
+            throw new RasterFormatException("negative or zero subimage height");
+        }
+        if (x < 0 || x >= width) {
+            throw new RasterFormatException("subimage x is outside raster");
+        }
+        if (x + w > width) {
+            throw new RasterFormatException(
+                    "subimage (x+width) is outside raster");
+        }
+        if (y < 0 || y >= height) {
+            throw new RasterFormatException("subimage y is outside raster");
+        }
+        if (y + h > height) {
+            throw new RasterFormatException(
+                    "subimage (y+height) is outside raster");
+        }
+
+        ImageBuilder b = new ImageBuilder(w, h, hasAlpha);
+        for(int i=0; i<h; i++){
+            int srcDex = (i+y)*width+x;
+            int outDex = i*w;
+            System.arraycopy(data, srcDex, b.data, outDex, w);
+        }
+        return b;
+    }
+
+
     /**
      * Gets a subimage from the ImageBuilder using the specified parameters.
      * If the parameters specify a rectangular region that is not entirely

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -588,17 +588,7 @@ public class TiffImageParser extends ImageParser implements XmpEmbeddable {
             if (subImage.y + subImage.height > height) {
                 throw new ImageReadException("subimage (y+height) is outside raster");
             }
-
-            // if the subimage is just the same thing as the whole
-            // image, suppress the subimage processing
-            if (subImage.x == 0
-                    && subImage.y == 0
-                    && subImage.width == width
-                    && subImage.height == height) {
-                subImage = null;
-            }
         }
-
 
         int samplesPerPixel = 1;
         final TiffField samplesPerPixelField = directory.findField(
@@ -679,17 +669,8 @@ public class TiffImageParser extends ImageParser implements XmpEmbeddable {
           samplesPerPixel, width, height, compression,
           planarConfiguration, byteOrder);
 
-        BufferedImage result = null;
-        if (subImage != null) {
-            result = dataReader.readImageData(subImage);
-        } else {
-            final boolean hasAlpha = false;
-            final ImageBuilder imageBuilder = new ImageBuilder(width, height, hasAlpha);
-
-            dataReader.readImageData(imageBuilder);
-            result =  imageBuilder.getBufferedImage();
-        }
-        return result;
+        final ImageBuilder iBuilder = dataReader.readImageData(subImage);
+        return iBuilder.getBufferedImage();
     }
 
     private PhotometricInterpreter getPhotometricInterpreter(

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderTiled.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/DataReaderTiled.java
@@ -24,7 +24,6 @@
 package org.apache.commons.imaging.formats.tiff.datareaders;
 
 import java.awt.Rectangle;
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -33,7 +32,6 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.formats.tiff.TiffRasterData;
 import org.apache.commons.imaging.formats.tiff.TiffDirectory;
-import org.apache.commons.imaging.formats.tiff.TiffElement.DataElement;
 import org.apache.commons.imaging.formats.tiff.TiffImageData;
 import org.apache.commons.imaging.formats.tiff.constants.TiffPlanarConfiguration;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
@@ -215,37 +213,18 @@ public final class DataReaderTiled extends ImageDataReader {
     }
 
     @Override
-    public void readImageData(final ImageBuilder imageBuilder)
+    public ImageBuilder readImageData(final Rectangle subImageSpecification)
             throws ImageReadException, IOException {
-        final int bitsPerRow = tileWidth * bitsPerPixel;
-        final int bytesPerRow = (bitsPerRow + 7) / 8;
-        final int bytesPerTile = bytesPerRow * tileLength;
-        int x = 0;
-        int y = 0;
 
-        for (final DataElement tile2 : imageData.tiles) {
-            final byte[] compressed = tile2.getData();
-
-            final byte[] decompressed = decompress(compressed, compression,
-                    bytesPerTile, tileWidth, tileLength);
-
-            interpretTile(imageBuilder, decompressed, x, y, width, height);
-
-            x += tileWidth;
-            if (x >= width) {
-                x = 0;
-                y += tileLength;
-                if (y >= height) {
-                    break;
-                }
-            }
-
+        final Rectangle subImage;
+        if (subImageSpecification == null) {
+            // configure subImage to read entire image
+            subImage = new Rectangle(0, 0, width, height);
+        } else {
+            subImage = subImageSpecification;
         }
-    }
 
-    @Override
-    public BufferedImage readImageData(final Rectangle subImage)
-            throws ImageReadException, IOException {
+
         final int bitsPerRow = tileWidth * bitsPerPixel;
         final int bytesPerRow = (bitsPerRow + 7) / 8;
         final int bytesPerTile = bytesPerRow * tileLength;
@@ -279,7 +258,7 @@ public final class DataReaderTiled extends ImageDataReader {
                         bytesPerTile, tileWidth, tileLength);
                 int x = iCol * tileWidth - x0;
                 int y = iRow * tileLength - y0;
-                interpretTile(workingBuilder, decompressed, x, y, workingWidth, workingHeight);
+                interpretTile(workingBuilder, decompressed, x, y, width, height);
             }
         }
 
@@ -287,9 +266,10 @@ public final class DataReaderTiled extends ImageDataReader {
                 && subImage.y == y0
                 && subImage.width == workingWidth
                 && subImage.height == workingHeight) {
-            return workingBuilder.getBufferedImage();
+            return workingBuilder;
         }
-        return workingBuilder.getSubimage(
+
+        return workingBuilder.getSubset(
             subImage.x - x0,
             subImage.y - y0,
             subImage.width,

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/ImageDataReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/datareaders/ImageDataReader.java
@@ -30,7 +30,6 @@ import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.TI
 import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.TIFF_FLAG_T6_OPTIONS_UNCOMPRESSED_MODE;
 
 import java.awt.Rectangle;
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -173,13 +172,19 @@ public abstract class ImageDataReader {
         last = new int[samplesPerPixel];
     }
 
-    // public abstract void readImageData(BufferedImage bi, ByteSource
-    // byteSource)
-    public abstract void readImageData(ImageBuilder imageBuilder)
-            throws ImageReadException, IOException;
 
-
-    public abstract BufferedImage readImageData(Rectangle subImage)
+    /**
+     * Read the image data from the IFD associated with this
+     * instance of ImageDataReader using the optional sub-image specification
+     * if desired.
+     * @param subImageSpecification a rectangle describing a sum-region of
+     * the image for reading, or a null if the whole image is to be read.
+     * @return a valid instance containing the pixel data from the image.
+     * @throws ImageReadException in the event of a data format error
+     * or other TIFF-specific failure.
+     * @throws IOException in the event of an unrecoverable I/O error.
+     */
+    public abstract ImageBuilder readImageData(Rectangle subImageSpecification)
             throws ImageReadException, IOException;
 
     /**


### PR DESCRIPTION
This change addresses IMAGING-269 by consolidating the redundant getImageData() methods from DataReaderStrips and DataReaderTiled.