### PR TITLE
IMAGING-168 - Encoding Support for IPTC metadata

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -487,7 +487,7 @@ public class IptcParser extends BinaryFileParser {
     }
 
     private Charset findCharset(byte[] codedCharset) {
-        String codedCharsetString = new String(codedCharset);
+        String codedCharsetString = new String(codedCharset, StandardCharsets.ISO_8859_1);
         try {
             if (Charset.isSupported(codedCharsetString)) {
                 return Charset.forName(codedCharsetString);

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -66,7 +66,7 @@ public class IptcParser extends BinaryFileParser {
      * @since 1.0-alpha2
      */
     private static final List<Integer> PHOTOSHOP_IGNORED_BLOCK_TYPE = Arrays.asList(1084, 1085, 1086, 1087);
-    
+
     private static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
     private static final int ENV_TAG_CODED_CHARACTER_SET = 90;
     private static final byte[] CHARACTER_ESCAPE_SEQUENCE = {'\u001B', '%', 'G'};
@@ -503,8 +503,9 @@ public class IptcParser extends BinaryFileParser {
             }
         }
 
-        if( Objects.deepEquals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE) )
+        if( Objects.deepEquals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE) ) {
             return StandardCharsets.UTF_8;
+        }
         return DEFAULT_CHARSET;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -209,7 +209,7 @@ public class IptcParser extends BinaryFileParser {
             // Debug.debug("recordSize", recordSize + " (0x"
             // + Integer.toHexString(recordSize) + ")");
 
-            if( recordNumber==IptcConstants.IPTC_ENVELOPE_RECORD_NUMBER && recordType==ENV_TAG_CODED_CHARACTER_SET ) {
+            if (recordNumber == IptcConstants.IPTC_ENVELOPE_RECORD_NUMBER && recordType == ENV_TAG_CODED_CHARACTER_SET) {
                 charset = findCharset(recordData);
                 continue;
             }
@@ -428,7 +428,7 @@ public class IptcParser extends BinaryFileParser {
         byte[] blockData;
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (BinaryOutputStream bos = new BinaryOutputStream(baos, getByteOrder())) {
-            if( charset!=null && !charset.equals(DEFAULT_CHARSET) ) {
+            if (charset != null && !charset.equals(DEFAULT_CHARSET)) {
                 bos.write(IptcConstants.IPTC_RECORD_TAG_MARKER);
                 bos.write(IptcConstants.IPTC_ENVELOPE_RECORD_NUMBER);
                 bos.write(ENV_TAG_CODED_CHARACTER_SET);
@@ -503,7 +503,7 @@ public class IptcParser extends BinaryFileParser {
             }
         }
 
-        if( Objects.deepEquals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE) ) {
+        if (Objects.deepEquals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE)) {
             return StandardCharsets.UTF_8;
         }
         return DEFAULT_CHARSET;


### PR DESCRIPTION
Encoding support for IPTC blocks when reading and writing image metadata.

When parsing IPTC blocks, encoded charset should be taken into account.

When writing IPTC blocks, if values can't be decoded in ISO-8859-1, UTF-8 should be used instead.

Related jira issue: [IPTC parser should use CodedCharacterSet tag to determine encoding of the IPTC tag values](https://issues.apache.org/jira/projects/IMAGING/issues/IMAGING-168)