### PR TITLE
IMAGING-310 JpegImageParser.getImageInfo() Refactor colorType logic to first look at numberOfComponents

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -824,44 +824,44 @@ public class JpegImageParser extends ImageParser implements XmpEmbeddable {
 
         // See http://docs.oracle.com/javase/6/docs/api/javax/imageio/metadata/doc-files/jpeg_metadata.html#color
         ImageInfo.ColorType colorType = ImageInfo.ColorType.UNKNOWN;
-        // Some images have both JFIF/APP0 and APP14.
-        // JFIF is meant to win but in them APP14 is clearly right, so make it win.
-        if (app14Segment != null && app14Segment.isAdobeJpegSegment()) {
-            final int colorTransform = app14Segment.getAdobeColorTransform();
-            switch (colorTransform) {
-            case App14Segment.ADOBE_COLOR_TRANSFORM_UNKNOWN:
-                if (numberOfComponents == 3) {
-                    colorType = ImageInfo.ColorType.RGB;
-                } else if (numberOfComponents == 4) {
-                    colorType = ImageInfo.ColorType.CMYK;
+        switch (numberOfComponents) {
+        case 1:
+            colorType = ImageInfo.ColorType.GRAYSCALE;
+            break;
+        case 2:
+            colorType = ImageInfo.ColorType.GRAYSCALE;
+            transparent = true;
+            break;
+        case 3:
+        case 4:
+            // Some images have both JFIF/APP0 and APP14.
+            // JFIF is meant to win but in them APP14 is clearly right, so make it win.
+            if (app14Segment != null && app14Segment.isAdobeJpegSegment()) {
+                final int colorTransform = app14Segment.getAdobeColorTransform();
+                switch (colorTransform) {
+                case App14Segment.ADOBE_COLOR_TRANSFORM_UNKNOWN:
+                    if (numberOfComponents == 3) {
+                        colorType = ImageInfo.ColorType.RGB;
+                    } else if (numberOfComponents == 4) {
+                        colorType = ImageInfo.ColorType.CMYK;
+                    }
+                    break;
+                case App14Segment.ADOBE_COLOR_TRANSFORM_YCbCr:
+                    colorType = ImageInfo.ColorType.YCbCr;
+                    break;
+                case App14Segment.ADOBE_COLOR_TRANSFORM_YCCK:
+                    colorType = ImageInfo.ColorType.YCCK;
+                    break;
+                default:
+                    break;
                 }
-                break;
-            case App14Segment.ADOBE_COLOR_TRANSFORM_YCbCr:
-                colorType = ImageInfo.ColorType.YCbCr;
-                break;
-            case App14Segment.ADOBE_COLOR_TRANSFORM_YCCK:
-                colorType = ImageInfo.ColorType.YCCK;
-                break;
-            default:
-                break;
-            }
-        } else if (jfifSegment != null) {
-            if (numberOfComponents == 1) {
-                colorType = ImageInfo.ColorType.GRAYSCALE;
-            } else if (numberOfComponents == 3) {
-                colorType = ImageInfo.ColorType.YCbCr;
-            }
-        } else {
-            switch (numberOfComponents) {
-            case 1:
-                colorType = ImageInfo.ColorType.GRAYSCALE;
-                break;
-            case 2:
-                colorType = ImageInfo.ColorType.GRAYSCALE;
-                transparent = true;
-                break;
-            case 3:
-            case 4:
+            } else if (jfifSegment != null) {
+                if (numberOfComponents == 1) {
+                    colorType = ImageInfo.ColorType.GRAYSCALE;
+                } else if (numberOfComponents == 3) {
+                    colorType = ImageInfo.ColorType.YCbCr;
+                }
+            } else {
                 boolean have1 = false;
                 boolean have2 = false;
                 boolean have3 = false;
@@ -959,9 +959,9 @@ public class JpegImageParser extends ImageParser implements XmpEmbeddable {
                     }
                 }
                 break;
-            default:
-                break;
             }
+        default:
+            break;
         }
 
         final ImageInfo.CompressionAlgorithm compressionAlgorithm = ImageInfo.CompressionAlgorithm.JPEG;


### PR DESCRIPTION
fix for IMAGING-310 JpegImageParser: Grayscale JPEG file with app14Segment returns ColorType.UNKNOWN