### PR TITLE
IMAGING-312 Corrected handling of ExtraSamples tag

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -147,6 +147,9 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="IMAGING-266" dev="kinow" type="fix" due-to="Gary Lucas">
         Read integer data from GeoTIFFS
       </action>
+      <action issue="IMAGING-312" dev="kinow" type="fix" due-to="Gary Lucas">
+        Corrected handling of ExtraSamples tag
+      </action>
     </release>
     <release version="1.0-alpha2" date="2020-08-01" description="Second 1.0 alpha release">
       <action issue="IMAGING-258" dev="kinow" type="update" due-to="Gary Lucas">


### PR DESCRIPTION
While this change addresses the special case of pre-multiplied alpha, there may be some system and JVM-version dependent issues. 