### PR TITLE
Imaging-327, change getExif method name

### DIFF
--- a/src/conf/spotbugs-exclude-filter.xml
+++ b/src/conf/spotbugs-exclude-filter.xml
@@ -180,12 +180,12 @@
   </Match>
   <Match>
     <Class name="org.apache.commons.imaging.formats.tiff.TiffImagingParameters" />
-    <Method name="getExif" />
+    <Method name="getOutputSet" />
     <Bug pattern="EI_EXPOSE_REP" />
   </Match>
   <Match>
     <Class name="org.apache.commons.imaging.formats.tiff.TiffImagingParameters" />
-    <Method name="setExif" />
+    <Method name="setOutputSet" />
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>
   <!-- Reason: For code clarity, we could use a simple 'else', but instead keep a complete expression -->

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
@@ -119,7 +119,7 @@ public class TiffImagingParameters extends XmpImagingParameters {
      * Set the TIFF output set for writing TIFF files.  An output set
      * may contain various types of TiffDirectories including image directories,
      * EXIF directories, GPS-related directories, etc.
-     * 
+     *
      * @param tiffOutputSet A valid instance.
      */
     public void setOutputSet(TiffOutputSet tiffOutputSet) {

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
@@ -33,9 +33,10 @@ public class TiffImagingParameters extends XmpImagingParameters {
     private boolean readThumbnails = true;
 
     /**
-     * User provided {@code TiffOutputSet} used to write into the image's EXIF metadata.
+     * User provided {@code TiffOutputSet} used to write into
+     * the image's EXIF metadata.
      */
-    private TiffOutputSet exif = null;
+    private TiffOutputSet tiffOutputSet = null;
 
     /**
      * X-coordinate of a sub-image.
@@ -106,12 +107,23 @@ public class TiffImagingParameters extends XmpImagingParameters {
         this.readThumbnails = readThumbnails;
     }
 
+    /**
+     * Get the TIFF output set for writing TIFF files.
+     * @return if set, a valid instance; otherwise, a null reference.
+     */
     public TiffOutputSet getExif() {
-        return exif;
+        return tiffOutputSet;
     }
 
-    public void setExif(TiffOutputSet exif) {
-        this.exif = exif;
+    /**
+     * Set the TIFF output set for writing TIFF files.  An output set
+     * may contain various types of TiffDirectories including image directories,
+     * EXIF directories, GPS-related directories, etc.
+     * 
+     * @param tiffOutputSet A valid instance.
+     */
+    public void setOutputSet(TiffOutputSet tiffOutputSet) {
+        this.tiffOutputSet = tiffOutputSet;
     }
 
     /**

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImagingParameters.java
@@ -34,7 +34,7 @@ public class TiffImagingParameters extends XmpImagingParameters {
 
     /**
      * User provided {@code TiffOutputSet} used to write into
-     * the image's EXIF metadata.
+     * the image's metadata including standard directory and EXIF tags.
      */
     private TiffOutputSet tiffOutputSet = null;
 
@@ -111,7 +111,7 @@ public class TiffImagingParameters extends XmpImagingParameters {
      * Get the TIFF output set for writing TIFF files.
      * @return if set, a valid instance; otherwise, a null reference.
      */
-    public TiffOutputSet getExif() {
+    public TiffOutputSet getOutputSet() {
         return tiffOutputSet;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterBase.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterBase.java
@@ -302,7 +302,7 @@ public abstract class TiffImageWriterBase {
 
     public void writeImage(final BufferedImage src, final OutputStream os, TiffImagingParameters params)
             throws ImageWriteException, IOException {
-        TiffOutputSet userExif = params.getExif();
+        TiffOutputSet userExif = params.getOutputSet();
 
         String xmpXml = params.getXmpXml();
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MicrosoftTagTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/MicrosoftTagTest.java
@@ -59,7 +59,7 @@ public class MicrosoftTagTest extends ExifBaseTest {
         root.add(MicrosoftTagConstants.EXIF_TAG_XPSUBJECT, SUBJECT);
         root.add(MicrosoftTagConstants.EXIF_TAG_XPTITLE, TITLE);
         final TiffImagingParameters params = new TiffImagingParameters();
-        params.setExif(exifSet);
+        params.setOutputSet(exifSet);
         TiffImageParser tiffImageParser = new TiffImageParser();
         final byte[] bytes;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {


### PR DESCRIPTION
I am submitting the method-name change as described in Imaging-327.   

I have made only minimal changes for internal member element names and limited my work to just the TiffImagingParameters class and its unit test.