### PR TITLE
IMAGING-319: Correct length calculation in EXIF rewriter

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossless.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossless.java
@@ -237,16 +237,18 @@ public class TiffImageWriterLossless extends TiffImageWriterBase {
                 overflowIndex += outputItemLength;
             } else {
                 long offset = bestFit.offset;
+                int  length = bestFit.length;
                 if ((offset & 1L) != 0) {
                     offset += 1;
+                    length -= 1;
                 }
                 outputItem.setOffset(offset);
                 unusedElements.remove(bestFit);
 
-                if (bestFit.length > outputItemLength) {
+                if (length > outputItemLength) {
                     // not a perfect fit.
-                    final long excessOffset = bestFit.offset + outputItemLength;
-                    final int excessLength = bestFit.length - outputItemLength;
+                    final long excessOffset = offset + outputItemLength;
+                    final int excessLength  = length - outputItemLength;
                     unusedElements.add(new TiffElement.Stub(excessOffset,
                             excessLength));
                     // make sure the new element is in the correct order.


### PR DESCRIPTION
I added comments to the JIRA ticket on this item at [IMAGING-319](https://issues.apache.org/jira/browse/IMAGING-319)

Unfortunately, it will be hard for me to create a JUnit test to specifically test this change without actually adding the user's original file (which is large) to our code distribution. 

The following text shows the problem.  
The users' test program read the data and then re-wrote it using the Commons Imaging library.  In the code below, his original File variable is named "source" and the rewritten version is named "result".
 

    ImageMetadata metadata2 = Imaging.getMetadata(source);  // or result
    JpegImageMetadata jpegMetadata2 = (JpegImageMetadata) metadata2;
    TiffImageMetadata exif2 = jpegMetadata2.getExif();
    String s2 = exif2.toString();
    System.out.println("\n" + s2 + "\n");

The printout for the original EXIF block (with many elements removed) comes up as:
    Exif: 
        ExifVersion: 48, 50, 51, 50
        DateTimeOriginal: '2021:10:28 13:47:07'
        DateTimeDigitized: '2021:10:28 13:47:07'
        Unknown Tag (0x9010): '-05:00'
        Unknown Tag (0x9011): '-05:00'
        Unknown Tag (0x9012): '-05:00'

Unknown tag 0x9010 is fine.  But if you perform the same thing on this result, it comes up with the first character in Tag 0x9010 as a comma rather than a negative sign as shown below:

    Exif: 
        Unknown Tag (0x9010): , 05:00
        Unknown Tag (0x9011): '-05:00'
        Unknown Tag (0x9012): '-05:00'

The attached fix repairs the problem and causes the EXIF tag to be printed correctly.

Here's the full code for the test program:

    import java.io.BufferedOutputStream;
    import java.io.File;
    import java.io.FileOutputStream;
    import java.io.IOException;
    import org.apache.commons.imaging.ImageReadException;
    import org.apache.commons.imaging.ImageWriteException;
    import org.apache.commons.imaging.Imaging;
    import org.apache.commons.imaging.common.ImageMetadata;
    import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
    import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
    import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
    import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;

     
    public class CommonsIssue319 {

      public static void main(String[] args) throws ImageReadException, IOException, ImageWriteException {
        File source = new File("iPhone12-geotag.JPG");
        File result = new File("editted-iPhone12-geotag.JPG");
        final ImageMetadata metadata = Imaging.getMetadata(source);
        final JpegImageMetadata jpegMetadata = (JpegImageMetadata) metadata;
        final TiffImageMetadata exif = jpegMetadata.getExif();
        String s = exif.toString();
        System.out.println("\n" + s + "\n");
        TiffOutputSet outputSet = exif.getOutputSet();
        BufferedOutputStream bufferedOutputStream = new 
        BufferedOutputStream(new FileOutputStream(result));
        new ExifRewriter().updateExifMetadataLossless(source, 
        bufferedOutputStream, outputSet);
        bufferedOutputStream.flush();
        bufferedOutputStream.close();

        ImageMetadata metadata2 = Imaging.getMetadata(result);
        JpegImageMetadata jpegMetadata2 = (JpegImageMetadata) metadata2;
        TiffImageMetadata exif2 = jpegMetadata2.getExif();
        String s2 = exif2.toString();
        System.out.println("\n" + s2 + "\n");
      }
