### PR TITLE
Imaging 330: Add PNG predictor to reduce output size

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImagingParameters.java
@@ -37,6 +37,8 @@ public class PngImagingParameters extends XmpImagingParameters {
 
     private boolean forceTrueColor = false;
 
+    private boolean predictorEnabled = false;
+
     /**
      * Used in write operations to indicate the Physical Scale - sCAL.
      *
@@ -91,5 +93,28 @@ public class PngImagingParameters extends XmpImagingParameters {
 
     public void setTextChunks(List<? extends PngText> textChunks) {
         this.textChunks = Collections.unmodifiableList(textChunks);
+    }
+
+    /**
+     * Indicates that the PNG write operation should enable
+     * the predictor.
+     * @return true if the predictor is enabled; otherwise, false.
+     */
+    public boolean isPredictorEnabled(){
+        return predictorEnabled;
+    }
+
+    /**
+     * Sets the enabled status of the predictor. When performing
+     * data compression on an image, a PNG predictor often results in a
+     * reduced file size. Predictors are particularly effective on
+     * photographic images, but may also work on graphics.
+     * The specification of a predictor may result in an increased
+     * processing time when writing an image, but will not affect the
+     * time required to read an image.
+     * @param predictorEnabled true if a predictor is enabled; otherwise, false.
+     */
+    public void setPredictorEnabled(boolean predictorEnabled){
+        this.predictorEnabled = predictorEnabled;
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.commons.imaging.formats.png;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.apache.commons.imaging.ImageWriteException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Provides a test for the PngWriter using predictors
+ */
+public class PngWritePredictorTest {
+
+  public PngWritePredictorTest() {
+  }
+
+  @BeforeAll
+  public static void setUpClass() {
+  }
+
+  @BeforeEach
+  public void setUp() {
+  }
+
+  /**
+   * Populate an integer pixel array for a 256-by-256 image
+   * with varied colors across the image area and a white and
+   * black line down the main diagonal.
+   * @return a valid array of integers.
+   */
+  private int[] populateARGB() {
+    //populate array with a blend of color components
+    int[] argb = new int[256 * 256];
+    for (int i = 0; i < 256; i++) {
+      for (int j = 0; j < 256; j++) {
+        int red = i;
+        int green = (255 - i);
+        int blue = j;
+        argb[i * 256 + j] = ((((0xff00 | red) << 8) | green) << 8) | blue;
+      }
+    }
+
+    // also draw a black and white strip down main diagonal
+    for (int i = 0; i < 256; i++) {
+      argb[i * 256 + i] = 0xff000000;
+      if (i < 255) {
+        argb[i * 256 + i + 1] = 0xffffffff;
+      }
+    }
+    return argb;
+  }
+
+  @Test
+  void testWriteWithPredictor() {
+    int[] argb = populateARGB();
+
+    // Test the RGB (no alpha) case ---------------------
+    BufferedImage bImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_RGB);
+    bImage.setRGB(0, 0, 256, 256, argb, 0, 256);
+
+    File tempFile = null;
+
+    try {
+      tempFile = File.createTempFile("PngWritePredictorRGB", ".png");
+    } catch (IOException ioex) {
+      fail("Failed to create temporary file, " + ioex.getMessage());
+    }
+    PngImagingParameters params = new PngImagingParameters();
+    params.setPredictorEnabled(true);
+    PngImageParser parser = new PngImageParser();
+    try ( FileOutputStream fos = new FileOutputStream(tempFile);  BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+      parser.writeImage(bImage, bos, params);
+      bos.flush();
+    } catch (IOException | ImageWriteException ex) {
+      fail("Failed writing RGB with exception " + ex.getMessage());
+    }
+
+    try {
+      int[] brgb = new int[256 * 256];
+      bImage = ImageIO.read(tempFile);
+      bImage.getRGB(0, 0, 256, 256, brgb, 0, 256);
+      assertArrayEquals(argb, brgb, "Round trip for RGB failed");
+    } catch (IOException ex) {
+      fail("Failed reading RGB with exception " + ex.getMessage());
+    }
+
+     // Test the ARGB (some semi-transparent alpha) case ---------------------
+    for (int i = 0; i < 256; i++) {
+      argb[i * 256 + i] &= 0x88ffffff;
+    }
+    bImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_ARGB);
+    bImage.setRGB(0, 0, 256, 256, argb, 0, 256);
+    try ( FileOutputStream fos = new FileOutputStream(tempFile);  BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+      parser.writeImage(bImage, bos, params);
+      bos.flush();
+    } catch (IOException | ImageWriteException ex) {
+      fail("Failed writing ARGB with exception " + ex.getMessage());
+    }
+    try {
+      int[] brgb = new int[256 * 256];
+      bImage = ImageIO.read(tempFile);
+      bImage.getRGB(0, 0, 256, 256, brgb, 0, 256);
+      assertArrayEquals(argb, brgb, "Round trip for ARGB failed");
+    } catch (IOException ex) {
+      fail("Failed reading ARGB with exception " + ex.getMessage());
+    }
+
+  }
+}


### PR DESCRIPTION
This change enhances the PngWriter class and PngImagingParameters class to allow the use of predictors. This change should reduce the size of output images written in PNG format. The resulting images will carry exactly the same data. There will be no loss of pixels or image quality. But the results will be smaller than those currently produced by either Imaging or Java's ImageIO class.

The default setting for PngImagingParameters is currently to not apply a predictor. So it is consistent with the existing behavior.

I am going to let this run through the build process.  When I see how the coverage analysis plays out, I will write a new JUnit test (if necessary) and submit it as part of this Pull Request.
