### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/bytesource/ByteSourceTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.ImagingTest;
@@ -32,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 public abstract class ByteSourceTest extends ImagingTest {
     protected File createTempFile(final byte[] src) throws IOException {
-        final File file = File.createTempFile("raw_", ".bin");
+        final File file = Files.createTempFile("raw_", ".bin").toFile();
 
         // write test bytes to file.
         try (FileOutputStream fos = new FileOutputStream(file); OutputStream os = new BufferedOutputStream(fos)) {

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -139,7 +140,7 @@ public class BmpRoundtripTest extends BmpBaseTest {
 
         final byte[] bytes = Imaging.writeImageToBytes(srcImage, ImageFormats.BMP);
 
-        final File tempFile = File.createTempFile("temp", ".bmp");
+        final File tempFile = Files.createTempFile("temp", ".bmp").toFile();
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
@@ -408,7 +409,7 @@ public class IcnsRoundTripTest extends IcnsBaseTest {
     private void writeAndReadImageData(final String description, final byte[] rawData,
             final int foreground, final int background) throws IOException,
             ImageReadException {
-        final File exportFile = File.createTempFile(description, ".icns");
+        final File exportFile = Files.createTempFile(description, ".icns").toFile();
         FileUtils.writeByteArrayToFile(exportFile, rawData);
         final BufferedImage dstImage = Imaging.getBufferedImage(exportFile);
 

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoRoundtripTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -538,7 +539,7 @@ public class IcoRoundtripTest extends IcoBaseTest {
         // File exportFile = new File("/tmp/" + description + ".ico");
         // IoUtils.writeToFile(rawData, exportFile);
 
-        final File tempFile = File.createTempFile("temp", ".ico");
+        final File tempFile = Files.createTempFile("temp", ".ico").toFile();
         FileUtils.writeByteArrayToFile(tempFile, rawData);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(tempFile);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +84,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = File.createTempFile("test", ".jpg");
+                final File tempFile = Files.createTempFile("test", ".jpg").toFile();
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -122,7 +123,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = File.createTempFile("removed", ".jpg");
+                final File tempFile = Files.createTempFile("removed", ".jpg").toFile();
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -143,7 +144,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                         outputSet);
 
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = File.createTempFile("inserted" + "_", ".jpg");
+                final File tempFile = Files.createTempFile("inserted" + "_", ".jpg").toFile();
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 
@@ -210,7 +211,7 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 rewriter.rewrite(byteSource, baos, outputSet);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = File.createTempFile(name + "_", ".jpg");
+                final File tempFile = Files.createTempFile(name + "_", ".jpg").toFile();
                 Debug.debug("tempFile", tempFile);
                 FileUtils.writeByteArrayToFile(tempFile, bytes);
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/WriteExifMetadataExampleTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.imaging.formats.jpeg.exif;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
@@ -46,7 +47,7 @@ public class WriteExifMetadataExampleTest extends ExifBaseTest {
     public void testOddOffsets(final File imageFile) throws Exception {
         Debug.debug("imageFile", imageFile.getAbsoluteFile());
 
-        final File tempFile = File.createTempFile("test", ".jpg");
+        final File tempFile = Files.createTempFile("test", ".jpg").toFile();
         Debug.debug("tempFile", tempFile.getAbsoluteFile());
 
         try {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
@@ -24,6 +24,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -75,7 +76,7 @@ public class IptcAddTest extends IptcBaseTest {
 
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords, newBlocks);
 
-        final File updated = File.createTempFile(imageFile.getName() + ".iptc.add.", ".jpg");
+        final File updated = Files.createTempFile(imageFile.getName() + ".iptc.add.", ".jpg").toFile();
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {
             new JpegIptcRewriter().writeIPTC(byteSource, os, newData);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -71,7 +72,7 @@ public class IptcUpdateTest extends IptcBaseTest {
     }
 
     public File removeIptc(final ByteSource byteSource, final File imageFile) throws Exception {
-        final File noIptcFile = File.createTempFile(imageFile.getName() + ".iptc.remove.", ".jpg");
+        final File noIptcFile = Files.createTempFile(imageFile.getName() + ".iptc.remove.", ".jpg").toFile();
 
         try (OutputStream os = new BufferedOutputStream(new FileOutputStream(noIptcFile))) {
             new JpegIptcRewriter().removeIPTC(byteSource, os);
@@ -102,8 +103,8 @@ public class IptcUpdateTest extends IptcBaseTest {
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords,
                 newBlocks);
 
-        final File updated = File.createTempFile(imageFile.getName()
-                + ".iptc.insert.", ".jpg");
+        final File updated = Files.createTempFile(imageFile.getName()
+                + ".iptc.insert.", ".jpg").toFile();
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {
             new JpegIptcRewriter().writeIPTC(new ByteSourceFile(
@@ -149,8 +150,8 @@ public class IptcUpdateTest extends IptcBaseTest {
     }
 
     public File writeIptc(final ByteSource byteSource, final PhotoshopApp13Data newData, final File imageFile) throws IOException, ImageReadException, ImageWriteException {
-        final File updated = File.createTempFile(imageFile.getName()
-                + ".iptc.update.", ".jpg");
+        final File updated = Files.createTempFile(imageFile.getName()
+                + ".iptc.update.", ".jpg").toFile();
         try (FileOutputStream fos = new FileOutputStream(updated);
                 OutputStream os = new BufferedOutputStream(fos)) {
             new JpegIptcRewriter().writeIPTC(byteSource, os, newData);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
@@ -24,6 +24,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSource;
@@ -48,7 +49,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
         final String xmpXml = new JpegImageParser().getXmpXml(byteSource, params);
         assertNotNull(xmpXml);
 
-        final File noXmpFile = File.createTempFile(imageFile.getName() + ".", ".jpg");
+        final File noXmpFile = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
         {
             // test remove
 
@@ -69,7 +70,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test update
 
             final String newXmpXml = "test";
-            final File updated = File.createTempFile(imageFile.getName() + ".", ".jpg");
+            final File updated = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
             try (FileOutputStream fos = new FileOutputStream(updated);
                     OutputStream os = new BufferedOutputStream(fos)) {
                 new JpegXmpRewriter().updateXmpXml(byteSource, os, newXmpXml);
@@ -88,7 +89,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test insert
 
             final String newXmpXml = "test";
-            final File updated = File.createTempFile(imageFile.getName() + ".", ".jpg");
+            final File updated = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
             try (FileOutputStream fos = new FileOutputStream(updated);
                     OutputStream os = new BufferedOutputStream(fos)) {
                 new JpegXmpRewriter().updateXmpXml(new ByteSourceFile(

--- a/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/ConvertPngToGifTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,7 +45,7 @@ public class ConvertPngToGifTest extends PngBaseTest {
             final BufferedImage image = Imaging.getBufferedImage(imageFile);
             assertNotNull(image);
 
-            final File outFile = File.createTempFile(imageFile.getName() + ".", ".gif");
+            final File outFile = Files.createTempFile(imageFile.getName() + ".", ".gif").toFile();
 
             Imaging.writeImage(image, outFile, ImageFormats.GIF);
         }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngMultipleRoundtripTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,7 +57,7 @@ public class PngMultipleRoundtripTest extends PngBaseTest {
                 final BufferedImage image = Imaging.getBufferedImage(lastFile);
                 assertNotNull(image);
 
-                final File tempFile = File.createTempFile(imageFile.getName() + "." + j + ".", ".png");
+                final File tempFile = Files.createTempFile(imageFile.getName() + "." + j + ".", ".png").toFile();
                 Debug.debug("tempFile", tempFile);
 
                 Imaging.writeImage(image, tempFile, ImageFormats.PNG);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
@@ -25,6 +25,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -73,7 +74,7 @@ public class PngTextTest extends PngBaseTest {
             bytes = baos.toByteArray();
         }
 
-        final File tempFile = File.createTempFile("temp", ".png");
+        final File tempFile = Files.createTempFile("temp", ".png").toFile();
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,7 +50,7 @@ public class PngWriteForceTrueColorText extends PngBaseTest {
                 final BufferedImage image = pngImageParser.getBufferedImage(imageFile, new PngImagingParameters());
                 assertNotNull(image);
 
-                final File outFile = File.createTempFile(imageFile.getName() + ".", ".gif");
+                final File outFile = Files.createTempFile(imageFile.getName() + ".", ".gif").toFile();
                 // Debug.debug("outFile", outFile);
 
                 final PngImagingParameters params = new PngImagingParameters();

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
@@ -24,6 +24,8 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+
 import javax.imageio.ImageIO;
 import org.apache.commons.imaging.ImageWriteException;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +88,7 @@ public class PngWritePredictorTest {
     File tempFile = null;
 
     try {
-      tempFile = File.createTempFile("PngWritePredictorRGB", ".png");
+      tempFile = Files.createTempFile("PngWritePredictorRGB", ".png").toFile();
     } catch (final IOException ioex) {
       fail("Failed to create temporary file, " + ioex.getMessage());
     }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
@@ -31,6 +31,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -182,7 +183,7 @@ public class PngWriteReadTest extends ImagingTest {
 
         final byte[] bytes = Imaging.writeImageToBytes(srcImage, ImageFormats.PNG);
 
-        final File tempFile = File.createTempFile("temp", ".png");
+        final File tempFile = Files.createTempFile("temp", ".png").toFile();
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
@@ -212,7 +213,7 @@ public class PngWriteReadTest extends ImagingTest {
             bytes = os.toByteArray();
         }
 
-        final File tempFile = File.createTempFile("temp", ".png");
+        final File tempFile = Files.createTempFile("temp", ".png").toFile();
         FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,7 +58,7 @@ public class TiffRoundtripTest extends TiffBaseTest {
             };
             final TiffImageParser tiffImageParser = new TiffImageParser();
             for (final int compression : compressions) {
-                final File tempFile = File.createTempFile(imageFile.getName() + "-" + compression + ".", ".tif");
+                final File tempFile = Files.createTempFile(imageFile.getName() + "-" + compression + ".", ".tif").toFile();
                 final TiffImagingParameters params = new TiffImagingParameters();
                 params.setCompression(compression);
                 try (FileOutputStream fos = new FileOutputStream(tempFile)) {

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,7 +65,7 @@ public class XmpUpdateTest extends ImagingTest {
                 continue;
             }
 
-            final File tempFile = File.createTempFile(imageFile.getName() + ".", "." + imageFormat.getDefaultExtension());
+            final File tempFile = Files.createTempFile(imageFile.getName() + ".", "." + imageFormat.getDefaultExtension()).toFile();
             final BufferedImage image = Imaging.getBufferedImage(imageFile);
 
             final ImageParser parser = Util.getImageParser("." + imageFormat.getDefaultExtension());

--- a/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,7 +38,7 @@ public class NullParametersRoundtripTest extends RoundtripBase {
     @MethodSource("data")
     public void testNullParametersRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(1, 1);
-        final File temp1 = File.createTempFile("nullParameters.", "." + formatInfo.format.getDefaultExtension());
+        final File temp1 = Files.createTempFile("nullParameters.", "." + formatInfo.format.getDefaultExtension()).toFile();
         Imaging.writeImage(testImage, temp1, formatInfo.format);
         Imaging.getImageInfo(temp1);
         Imaging.getImageSize(temp1);

--- a/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,7 +44,7 @@ public class PixelDensityRoundtrip extends RoundtripBase {
     public void testPixelDensityRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(2, 2);
 
-        final File temp1 = File.createTempFile("pixeldensity.", "." + formatInfo.format.getDefaultExtension());
+        final File temp1 = Files.createTempFile("pixeldensity.", "." + formatInfo.format.getDefaultExtension()).toFile();
 
         final TiffImagingParameters params = new TiffImagingParameters();
         final PixelDensity pixelDensity = PixelDensity.createFromPixelsPerInch(75, 150);

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -29,6 +29,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,8 +39,8 @@ public class RoundtripBase {
     protected void roundtrip(final FormatInfo formatInfo, final BufferedImage testImage,
                              final String tempPrefix, final boolean imageExact) throws IOException,
             ImageReadException, ImageWriteException {
-        final File temp1 = File.createTempFile(tempPrefix + ".", "."
-                + formatInfo.format.getDefaultExtension());
+        final File temp1 = Files.createTempFile(tempPrefix + ".", "."
+                + formatInfo.format.getDefaultExtension()).toFile();
         Debug.debug("tempFile: " + temp1.getName());
 
         final ImageParser imageParser = Util.getImageParser(formatInfo.format);
@@ -61,7 +62,7 @@ public class RoundtripBase {
         }
 
         if (formatInfo.identicalSecondWrite) {
-            final File temp2 = File.createTempFile(tempPrefix + ".", "." + formatInfo.format.getDefaultExtension());
+            final File temp2 = Files.createTempFile(tempPrefix + ".", "." + formatInfo.format.getDefaultExtension()).toFile();
             try (FileOutputStream fos = new FileOutputStream(temp2)) {
                 imageParser.writeImage(image2, fos, params);
             }


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
