### PR TITLE
Fix unit test

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -50,7 +50,7 @@ public class PngWriteForceTrueColorText extends PngBaseTest {
                 final BufferedImage image = pngImageParser.getBufferedImage(imageFile, new PngImagingParameters());
                 assertNotNull(image);
 
-                final File outFile = Files.createTempFile(imageFile.getName() + ".", ".gif").toFile();
+                final File outFile = Files.createTempFile(imageFile.getName() + ".", ".png").toFile();
                 // Debug.debug("outFile", outFile);
 
                 final PngImagingParameters params = new PngImagingParameters();

--- a/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/PixelDensityRoundtrip.java
@@ -27,8 +27,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,15 +42,14 @@ public class PixelDensityRoundtrip extends RoundtripBase {
     public void testPixelDensityRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(2, 2);
 
-        final File temp1 = Files.createTempFile("pixeldensity.", "." + formatInfo.format.getDefaultExtension()).toFile();
-
         final TiffImagingParameters params = new TiffImagingParameters();
         final PixelDensity pixelDensity = PixelDensity.createFromPixelsPerInch(75, 150);
         params.setPixelDensity(pixelDensity);
         final TiffImageParser tiffImageParser = new TiffImageParser();
-        tiffImageParser.writeImage(testImage, new ByteArrayOutputStream(), params);
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        tiffImageParser.writeImage(testImage, byteArrayOutputStream, params);
 
-        final ImageInfo imageInfo = Imaging.getImageInfo(temp1);
+        final ImageInfo imageInfo = Imaging.getImageInfo(byteArrayOutputStream.toByteArray());
         if (imageInfo != null) {
             final int xReadDPI = imageInfo.getPhysicalWidthDpi();
             final int yReadDPI = imageInfo.getPhysicalHeightDpi();


### PR DESCRIPTION
Fix two unit tests that were broken.
PixelDensityRoundtrip was now writing data in a byte array instead of a tmp file, but was trying to read the tmp file anyway.

And

PngWriteForceTrueColorText that was writing a png into a file named .gif, but was unable to read it because the extension was checked and refused by png parser.