### PR TITLE
[IMAGING-345] Unit test : make tests in memory instead of writing hundred of tmp files

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -22,13 +22,10 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -139,9 +136,6 @@ public class BmpRoundtripTest extends BmpBaseTest {
         final BufferedImage srcImage = imageDataToBufferedImage(rawData);
 
         final byte[] bytes = Imaging.writeImageToBytes(srcImage, ImageFormats.BMP);
-
-        final File tempFile = Files.createTempFile("temp", ".bmp").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
 

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsRoundTripTest.java
@@ -22,16 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.BinaryOutputStream;
 import org.apache.commons.imaging.internal.Debug;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 public class IcnsRoundTripTest extends IcnsBaseTest {
@@ -408,9 +406,7 @@ public class IcnsRoundTripTest extends IcnsBaseTest {
     private void writeAndReadImageData(final String description, final byte[] rawData,
             final int foreground, final int background) throws IOException,
             ImageReadException {
-        final File exportFile = Files.createTempFile(description, ".icns").toFile();
-        FileUtils.writeByteArrayToFile(exportFile, rawData);
-        final BufferedImage dstImage = Imaging.getBufferedImage(exportFile);
+        final BufferedImage dstImage = Imaging.getBufferedImage(new ByteArrayInputStream(rawData), "description.icns");
 
         assertNotNull(dstImage);
         assertEquals(dstImage.getWidth(), IMAGE[0].length);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifBaseTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifBaseTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 
@@ -36,6 +37,15 @@ public abstract class ExifBaseTest extends ImagingTest {
 
         try {
             final ByteSource byteSource = new ByteSourceFile(file);
+            return new JpegImageParser().hasExifSegment(byteSource);
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    protected static boolean hasExifData(final String fileName, final byte[] bytes) {
+        try {
+            final ByteSource byteSource = new ByteSourceArray(fileName, bytes);
             return new JpegImageParser().hasExifSegment(byteSource);
         } catch (final Exception e) {
             return false;

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -23,11 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,7 +49,6 @@ import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.fieldtypes.FieldType;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
 import org.apache.commons.imaging.internal.Debug;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -84,14 +83,11 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = Files.createTempFile("test", ".jpg").toFile();
-                Debug.debug("tempFile", tempFile);
-                FileUtils.writeByteArrayToFile(tempFile, bytes);
 
                 Debug.debug("Output Segments:");
                 new JpegUtils().dumpJFIF(new ByteSourceArray(bytes));
 
-                assertFalse(hasExifData(tempFile));
+                assertFalse(hasExifData("test.jpg", bytes));
             }
         }
     }
@@ -123,15 +119,12 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new ExifRewriter().removeExifMetadata(byteSource, baos);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = Files.createTempFile("removed", ".jpg").toFile();
-                Debug.debug("tempFile", tempFile);
-                FileUtils.writeByteArrayToFile(tempFile, bytes);
 
                 Debug.debug("Output Segments:");
                 stripped = new ByteSourceArray(bytes);
                 new JpegUtils().dumpJFIF(stripped);
 
-                assertFalse(hasExifData(tempFile));
+                assertFalse(hasExifData("removed.jpg", bytes));
             }
 
             {
@@ -144,16 +137,13 @@ public class ExifRewriteTest extends ExifBaseTest {
                         outputSet);
 
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = Files.createTempFile("inserted" + "_", ".jpg").toFile();
-                Debug.debug("tempFile", tempFile);
-                FileUtils.writeByteArrayToFile(tempFile, bytes);
 
                 Debug.debug("Output Segments:");
                 new JpegUtils().dumpJFIF(new ByteSourceArray(bytes));
 
                 // assertTrue(!hasExifData(tempFile));
 
-                final JpegImageMetadata newMetadata = (JpegImageMetadata) Imaging.getMetadata(tempFile);
+                final JpegImageMetadata newMetadata = (JpegImageMetadata) Imaging.getMetadata(new ByteArrayInputStream(bytes), "inserted.jpg");
                 assertNotNull(newMetadata);
                 final TiffImageMetadata newExifMetadata = newMetadata.getExif();
                 assertNotNull(newExifMetadata);
@@ -211,16 +201,13 @@ public class ExifRewriteTest extends ExifBaseTest {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 rewriter.rewrite(byteSource, baos, outputSet);
                 final byte[] bytes = baos.toByteArray();
-                final File tempFile = Files.createTempFile(name + "_", ".jpg").toFile();
-                Debug.debug("tempFile", tempFile);
-                FileUtils.writeByteArrayToFile(tempFile, bytes);
 
                 Debug.debug("Output Segments:");
                 new JpegUtils().dumpJFIF(new ByteSourceArray(bytes));
 
                 // assertTrue(!hasExifData(tempFile));
 
-                final JpegImageMetadata newMetadata = (JpegImageMetadata) Imaging.getMetadata(tempFile);
+                final JpegImageMetadata newMetadata = (JpegImageMetadata) Imaging.getMetadata(new ByteArrayInputStream(bytes), name + ".jpg");
                 assertNotNull(newMetadata);
                 final TiffImageMetadata newExifMetadata = newMetadata.getExif();
                 assertNotNull(newExifMetadata);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcAddTest.java
@@ -20,16 +20,14 @@ package org.apache.commons.imaging.formats.jpeg.iptc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegImagingParameters;
@@ -76,13 +74,13 @@ public class IptcAddTest extends IptcBaseTest {
 
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords, newBlocks);
 
-        final File updated = Files.createTempFile(imageFile.getName() + ".iptc.add.", ".jpg").toFile();
-        try (FileOutputStream fos = new FileOutputStream(updated);
-                OutputStream os = new BufferedOutputStream(fos)) {
+        byte[] bytes;
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             new JpegIptcRewriter().writeIPTC(byteSource, os, newData);
+            bytes = os.toByteArray();
         }
 
-        final ByteSource updateByteSource = new ByteSourceFile(updated);
+        final ByteSource updateByteSource = new ByteSourceArray("test.jpg", bytes);
         final JpegPhotoshopMetadata outMetadata = new JpegImageParser().getPhotoshopMetadata(
                 updateByteSource, params);
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcUpdateTest.java
@@ -21,12 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -34,6 +31,7 @@ import java.util.stream.Stream;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegImagingParameters;
@@ -61,23 +59,21 @@ public class IptcUpdateTest extends IptcBaseTest {
                 byteSource, params);
         assertNotNull(metadata);
 
-        final File noIptcFile = removeIptc(byteSource, imageFile);
+        final byte[] noIptcFile = removeIptc(byteSource, imageFile);
 
         final JpegPhotoshopMetadata outMetadata = new JpegImageParser().getPhotoshopMetadata(
-                new ByteSourceFile(noIptcFile), params);
+                new ByteSourceArray("test.jpg", noIptcFile), params);
 
         // FIXME should either be null or empty
         assertTrue(outMetadata == null
                 || outMetadata.getItems().isEmpty());
     }
 
-    public File removeIptc(final ByteSource byteSource, final File imageFile) throws Exception {
-        final File noIptcFile = Files.createTempFile(imageFile.getName() + ".iptc.remove.", ".jpg").toFile();
-
-        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(noIptcFile))) {
+    public byte[] removeIptc(final ByteSource byteSource, final File imageFile) throws Exception {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             new JpegIptcRewriter().removeIPTC(byteSource, os);
+            return os.toByteArray();
         }
-        return noIptcFile;
     }
 
     @ParameterizedTest
@@ -91,7 +87,7 @@ public class IptcUpdateTest extends IptcBaseTest {
                 byteSource, params);
         assertNotNull(metadata);
 
-        final File noIptcFile = removeIptc(byteSource, imageFile);
+        final byte[] noIptcFile = removeIptc(byteSource, imageFile);
 
         final List<IptcBlock> newBlocks = new ArrayList<>();
         final List<IptcRecord> newRecords = new ArrayList<>();
@@ -103,15 +99,14 @@ public class IptcUpdateTest extends IptcBaseTest {
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords,
                 newBlocks);
 
-        final File updated = Files.createTempFile(imageFile.getName()
-                + ".iptc.insert.", ".jpg").toFile();
-        try (FileOutputStream fos = new FileOutputStream(updated);
-                OutputStream os = new BufferedOutputStream(fos)) {
-            new JpegIptcRewriter().writeIPTC(new ByteSourceFile(
+        byte[] updated;
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            new JpegIptcRewriter().writeIPTC(new ByteSourceArray("test.jpg",
                     noIptcFile), os, newData);
+            updated = os.toByteArray();
         }
 
-        final ByteSource updateByteSource = new ByteSourceFile(updated);
+        final ByteSource updateByteSource = new ByteSourceArray("test.jpg", updated);
         final JpegPhotoshopMetadata outMetadata = new JpegImageParser().getPhotoshopMetadata(
                 updateByteSource, params);
 
@@ -139,9 +134,9 @@ public class IptcUpdateTest extends IptcBaseTest {
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords,
                 newBlocks);
 
-        final File updated = writeIptc(byteSource, newData, imageFile);
+        final byte[] updated = writeIptc(byteSource, newData, imageFile);
 
-        final ByteSource updateByteSource = new ByteSourceFile(updated);
+        final ByteSource updateByteSource = new ByteSourceArray("test.jpg", updated);
         final JpegPhotoshopMetadata outMetadata = new JpegImageParser().getPhotoshopMetadata(
                 updateByteSource, params);
 
@@ -149,14 +144,11 @@ public class IptcUpdateTest extends IptcBaseTest {
         assertEquals(2, outMetadata.getItems().size());
     }
 
-    public File writeIptc(final ByteSource byteSource, final PhotoshopApp13Data newData, final File imageFile) throws IOException, ImageReadException, ImageWriteException {
-        final File updated = Files.createTempFile(imageFile.getName()
-                + ".iptc.update.", ".jpg").toFile();
-        try (FileOutputStream fos = new FileOutputStream(updated);
-                OutputStream os = new BufferedOutputStream(fos)) {
+    public byte[] writeIptc(final ByteSource byteSource, final PhotoshopApp13Data newData, final File imageFile) throws IOException, ImageReadException, ImageWriteException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             new JpegIptcRewriter().writeIPTC(byteSource, os, newData);
+            return os.toByteArray();
         }
-        return updated;
     }
 
     @ParameterizedTest
@@ -184,9 +176,9 @@ public class IptcUpdateTest extends IptcBaseTest {
 
         final PhotoshopApp13Data newData = new PhotoshopApp13Data(newRecords, newBlocks);
 
-        final File updated = writeIptc(byteSource, newData, imageFile);
+        final byte[] updated = writeIptc(byteSource, newData, imageFile);
 
-        final ByteSource updateByteSource = new ByteSourceFile(updated);
+        final ByteSource updateByteSource = new ByteSourceArray("test.jpg", updated);
         final JpegPhotoshopMetadata outMetadata = new JpegImageParser().getPhotoshopMetadata(updateByteSource, params);
 
         assertNotNull(outMetadata);

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
@@ -20,14 +20,12 @@ package org.apache.commons.imaging.formats.jpeg.xmp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegImagingParameters;
@@ -49,20 +47,20 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
         final String xmpXml = new JpegImageParser().getXmpXml(byteSource, params);
         assertNotNull(xmpXml);
 
-        final File noXmpFile = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
+        byte[] noXmpFile;
         {
             // test remove
 
-            try (FileOutputStream fos = new FileOutputStream(noXmpFile);
-                    OutputStream os = new BufferedOutputStream(fos)) {
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                 new JpegXmpRewriter().removeXmpXml(byteSource, os);
+                noXmpFile = os.toByteArray();
             }
 
             // Debug.debug("Source Segments:");
             // new JpegUtils().dumpJFIF(new ByteSourceFile(noXmpFile));
 
             final String outXmp = new JpegImageParser().getXmpXml(
-                    new ByteSourceFile(noXmpFile), params);
+                    new ByteSourceArray("test.jpg", noXmpFile), params);
             Assertions.assertNull(outXmp);
         }
 
@@ -70,17 +68,17 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test update
 
             final String newXmpXml = "test";
-            final File updated = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
-            try (FileOutputStream fos = new FileOutputStream(updated);
-                    OutputStream os = new BufferedOutputStream(fos)) {
+            byte[] updated;
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                 new JpegXmpRewriter().updateXmpXml(byteSource, os, newXmpXml);
+                updated = os.toByteArray();
             }
 
             // Debug.debug("Source Segments:");
             // new JpegUtils().dumpJFIF(new ByteSourceFile(updated));
 
             final String outXmp = new JpegImageParser().getXmpXml(
-                    new ByteSourceFile(updated), params);
+                    new ByteSourceArray("test.jpg", updated), params);
             assertNotNull(outXmp);
             assertEquals(outXmp, newXmpXml);
         }
@@ -89,18 +87,18 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
             // test insert
 
             final String newXmpXml = "test";
-            final File updated = Files.createTempFile(imageFile.getName() + ".", ".jpg").toFile();
-            try (FileOutputStream fos = new FileOutputStream(updated);
-                    OutputStream os = new BufferedOutputStream(fos)) {
-                new JpegXmpRewriter().updateXmpXml(new ByteSourceFile(
+            final byte[] updated;
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                new JpegXmpRewriter().updateXmpXml(new ByteSourceArray("test.jpg",
                         noXmpFile), os, newXmpXml);
+                updated = os.toByteArray();
             }
 
             // Debug.debug("Source Segments:");
             // new JpegUtils().dumpJFIF(new ByteSourceFile(updated));
 
             final String outXmp = new JpegImageParser().getXmpXml(
-                    new ByteSourceFile(updated), params);
+                    new ByteSourceArray("test.jpg", updated), params);
             assertNotNull(outXmp);
             assertEquals(outXmp, newXmpXml);
         }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -73,9 +71,6 @@ public class PngTextTest extends PngBaseTest {
             pngImageParser.writeImage(srcImage, baos, writeParams);
             bytes = baos.toByteArray();
         }
-
-        final File tempFile = Files.createTempFile("temp", ".png").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(bytes);
         assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteForceTrueColorText.java
@@ -21,9 +21,8 @@ import org.apache.commons.imaging.internal.Debug;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,13 +49,14 @@ public class PngWriteForceTrueColorText extends PngBaseTest {
                 final BufferedImage image = pngImageParser.getBufferedImage(imageFile, new PngImagingParameters());
                 assertNotNull(image);
 
-                final File outFile = Files.createTempFile(imageFile.getName() + ".", ".png").toFile();
                 // Debug.debug("outFile", outFile);
 
                 final PngImagingParameters params = new PngImagingParameters();
-                params.setForceTrueColor(Boolean.TRUE);
-                try (FileOutputStream fos = new FileOutputStream(outFile)) {
-                    pngImageParser.writeImage(image, fos, params);
+                byte[] outFile;
+                try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                    params.setForceTrueColor(Boolean.TRUE);
+                    pngImageParser.writeImage(image, os, params);
+                    outFile = os.toByteArray();
                 }
 
                 final BufferedImage image2 = pngImageParser.getBufferedImage(outFile, new PngImagingParameters());

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWritePredictorTest.java
@@ -20,11 +20,9 @@
 package org.apache.commons.imaging.formats.png;
 
 import java.awt.image.BufferedImage;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import javax.imageio.ImageIO;
 import org.apache.commons.imaging.ImageWriteException;
@@ -85,26 +83,21 @@ public class PngWritePredictorTest {
     BufferedImage bImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_RGB);
     bImage.setRGB(0, 0, 256, 256, argb, 0, 256);
 
-    File tempFile = null;
+    byte[] tempFile = null;
 
-    try {
-      tempFile = Files.createTempFile("PngWritePredictorRGB", ".png").toFile();
-    } catch (final IOException ioex) {
-      fail("Failed to create temporary file, " + ioex.getMessage());
-    }
     final PngImagingParameters params = new PngImagingParameters();
     params.setPredictorEnabled(true);
     final PngImageParser parser = new PngImageParser();
-    try ( FileOutputStream fos = new FileOutputStream(tempFile);  BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
       parser.writeImage(bImage, bos, params);
-      bos.flush();
+      tempFile = bos.toByteArray();
     } catch (IOException | ImageWriteException ex) {
       fail("Failed writing RGB with exception " + ex.getMessage());
     }
 
     try {
       final int[] brgb = new int[256 * 256];
-      bImage = ImageIO.read(tempFile);
+      bImage = ImageIO.read(new ByteArrayInputStream(tempFile));
       bImage.getRGB(0, 0, 256, 256, brgb, 0, 256);
       assertArrayEquals(argb, brgb, "Round trip for RGB failed");
     } catch (final IOException ex) {
@@ -117,15 +110,15 @@ public class PngWritePredictorTest {
     }
     bImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_ARGB);
     bImage.setRGB(0, 0, 256, 256, argb, 0, 256);
-    try ( FileOutputStream fos = new FileOutputStream(tempFile);  BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
       parser.writeImage(bImage, bos, params);
-      bos.flush();
+      tempFile = bos.toByteArray();
     } catch (IOException | ImageWriteException ex) {
       fail("Failed writing ARGB with exception " + ex.getMessage());
     }
     try {
       final int[] brgb = new int[256 * 256];
-      bImage = ImageIO.read(tempFile);
+      bImage = ImageIO.read(new ByteArrayInputStream(tempFile));
       bImage.getRGB(0, 0, 256, 256, brgb, 0, 256);
       assertArrayEquals(argb, brgb, "Round trip for ARGB failed");
     } catch (final IOException ex) {

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriteReadTest.java
@@ -24,14 +24,11 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.common.ImageMetadata;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -183,9 +180,6 @@ public class PngWriteReadTest extends ImagingTest {
 
         final byte[] bytes = Imaging.writeImageToBytes(srcImage, ImageFormats.PNG);
 
-        final File tempFile = Files.createTempFile("temp", ".png").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
-
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
 
         assertNotNull(dstImage);
@@ -212,9 +206,6 @@ public class PngWriteReadTest extends ImagingTest {
             pngImageParser.writeImage(srcImage, os, writeParams);
             bytes = os.toByteArray();
         }
-
-        final File tempFile = Files.createTempFile("temp", ".png").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
 
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
 

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffRoundtripTest.java
@@ -25,9 +25,8 @@ import org.apache.commons.imaging.internal.Debug;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,11 +57,12 @@ public class TiffRoundtripTest extends TiffBaseTest {
             };
             final TiffImageParser tiffImageParser = new TiffImageParser();
             for (final int compression : compressions) {
-                final File tempFile = Files.createTempFile(imageFile.getName() + "-" + compression + ".", ".tif").toFile();
+                final byte[] tempFile;
                 final TiffImagingParameters params = new TiffImagingParameters();
                 params.setCompression(compression);
-                try (FileOutputStream fos = new FileOutputStream(tempFile)) {
-                    tiffImageParser.writeImage(image, fos, params);
+                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                    tiffImageParser.writeImage(image, bos, params);
+                    tempFile = bos.toByteArray();
                 }
                 final BufferedImage image2 = Imaging.getBufferedImage(tempFile);
                 assertNotNull(image2);

--- a/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xmp/XmpUpdateTest.java
@@ -29,7 +29,6 @@ import org.apache.commons.imaging.ImageFormat;
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.ImageParser;
 import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.ImagingParameters;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.XmpImagingParameters;
 import org.apache.commons.imaging.internal.Debug;

--- a/src/test/java/org/apache/commons/imaging/roundtrip/FormatInfo.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/FormatInfo.java
@@ -130,4 +130,16 @@ class FormatInfo {
         this.identicalSecondWrite = identicalSecondWrite;
         this.preservesResolution = preservesResolution;
     }
+
+    @Override
+    public String toString() {
+        return "FormatInfo{" +
+            "format=" + format +
+            ", canRead=" + canRead +
+            ", canWrite=" + canWrite +
+            ", colorSupport=" + colorSupport +
+            ", identicalSecondWrite=" + identicalSecondWrite +
+            ", preservesResolution=" + preservesResolution +
+            '}';
+    }
 }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.nio.file.Files;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,13 +38,17 @@ public class NullParametersRoundtripTest extends RoundtripBase {
     @MethodSource("data")
     public void testNullParametersRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(1, 1);
-        final File temp1 = Files.createTempFile("nullParameters.", "." + formatInfo.format.getDefaultExtension()).toFile();
-        Imaging.writeImage(testImage, temp1, formatInfo.format);
-        Imaging.getImageInfo(temp1);
-        Imaging.getImageSize(temp1);
-        Imaging.getMetadata(temp1);
-        Imaging.getICCProfile(temp1);
-        final BufferedImage imageRead = Imaging.getBufferedImage(temp1);
+        final byte[] temp1;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            Imaging.writeImage(testImage, byteArrayOutputStream, formatInfo.format);
+            temp1 = byteArrayOutputStream.toByteArray();
+        }
+        final String filename = "nullParameters." + formatInfo.format.getDefaultExtension();
+        Imaging.getImageInfo(new ByteArrayInputStream(temp1), filename);
+        Imaging.getImageSize(new ByteArrayInputStream(temp1), filename);
+        Imaging.getMetadata(new ByteArrayInputStream(temp1), filename);
+        Imaging.getICCProfile(new ByteArrayInputStream(temp1), filename);
+        final BufferedImage imageRead = Imaging.getBufferedImage(new ByteArrayInputStream(temp1), filename);
 
         assertNotNull(imageRead);
     }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -21,17 +21,15 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.ImagingParameters;
 import org.apache.commons.imaging.common.RgbBufferedImageFactory;
-import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.imaging.internal.ImageParserFactory;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RoundtripBase {
@@ -39,15 +37,14 @@ public class RoundtripBase {
     protected void roundtrip(final FormatInfo formatInfo, final BufferedImage testImage,
                              final String tempPrefix, final boolean imageExact) throws IOException,
             ImageReadException, ImageWriteException {
-        final File temp1 = Files.createTempFile(tempPrefix + ".", "."
-                + formatInfo.format.getDefaultExtension()).toFile();
-        Debug.debug("tempFile: " + temp1.getName());
 
         final ImageParser imageParser = ImageParserFactory.getImageParser(formatInfo.format);
 
         final ImagingParameters params = ImageParserFactory.getImageParser(formatInfo.format).getDefaultParameters();
-        try (FileOutputStream fos = new FileOutputStream(temp1)) {
-            imageParser.writeImage(testImage, fos, params);
+        byte[] temp1;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            imageParser.writeImage(testImage, bos, params);
+            temp1 = bos.toByteArray();
         }
 
         final ImagingParameters readParams = ImageParserFactory.getImageParser(formatInfo.format).getDefaultParameters();
@@ -62,12 +59,13 @@ public class RoundtripBase {
         }
 
         if (formatInfo.identicalSecondWrite) {
-            final File temp2 = Files.createTempFile(tempPrefix + ".", "." + formatInfo.format.getDefaultExtension()).toFile();
-            try (FileOutputStream fos = new FileOutputStream(temp2)) {
-                imageParser.writeImage(image2, fos, params);
+            byte[] temp2;
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                imageParser.writeImage(image2, bos, params);
+                temp2 = bos.toByteArray();
             }
 
-            ImageAsserts.assertEquals(temp1, temp2);
+            assertArrayEquals(temp1, temp2);
         }
     }
 


### PR DESCRIPTION
An attempt to perform unit tests in memory using byte array when possible instead of writing temporary files.
Tests pass much faster and do not make useless write on my SSD.
I know that having the tmp files might be useful in some case, if you  think it it necessary I could update the patch to write tmp file in case of failed test.