### PR TITLE
perform tests in memory instead of disk making them faster

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpRoundtripTest.java
@@ -22,13 +22,12 @@ import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImageWriteException;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.internal.Debug;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -140,17 +139,21 @@ public class BmpRoundtripTest extends BmpBaseTest {
 
         final byte[] bytes = Imaging.writeImageToBytes(srcImage, ImageFormats.BMP);
 
-        final File tempFile = Files.createTempFile("temp", ".bmp").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
-
         final BufferedImage dstImage = Imaging.getBufferedImage(bytes);
 
-        assertNotNull(dstImage);
-        assertEquals(srcImage.getWidth(), dstImage.getWidth());
-        assertEquals(srcImage.getHeight(), dstImage.getHeight());
+        try {
+            assertNotNull(dstImage);
+            assertEquals(srcImage.getWidth(), dstImage.getWidth());
+            assertEquals(srcImage.getHeight(), dstImage.getHeight());
 
-        final int[][] dstData = bufferedImageToImageData(dstImage);
-        compare(rawData, dstData);
+            final int[][] dstData = bufferedImageToImageData(dstImage);
+            compare(rawData, dstData);
+        } catch (final Throwable e) {
+            final Path tempFile = Files.createTempFile("temp", ".bmp");
+            Files.write(tempFile, bytes);
+            System.err.println("Failed tempFile " + tempFile);
+            throw e;
+        }
     }
 
     private void compare(final int[][] a, final int[][] b) {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifBaseTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifBaseTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.ImagingTest;
 import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceArray;
 import org.apache.commons.imaging.common.bytesource.ByteSourceFile;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 
@@ -36,6 +37,15 @@ public abstract class ExifBaseTest extends ImagingTest {
 
         try {
             final ByteSource byteSource = new ByteSourceFile(file);
+            return new JpegImageParser().hasExifSegment(byteSource);
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    protected static boolean hasExifData(final String fileName, final byte[] bytes) {
+        try {
+            final ByteSource byteSource = new ByteSourceArray(fileName, bytes);
             return new JpegImageParser().hasExifSegment(byteSource);
         } catch (final Exception e) {
             return false;

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngTextTest.java
@@ -74,24 +74,26 @@ public class PngTextTest extends PngBaseTest {
             bytes = baos.toByteArray();
         }
 
-        final File tempFile = Files.createTempFile("temp", ".png").toFile();
-        FileUtils.writeByteArrayToFile(tempFile, bytes);
+        try {
+            final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(bytes);
+            assertNotNull(imageInfo);
 
-        final PngImageInfo imageInfo = (PngImageInfo) Imaging.getImageInfo(bytes);
-        assertNotNull(imageInfo);
-
-        final List<PngText> readTexts = imageInfo.getTextChunks();
-        assertEquals(readTexts.size(), 3);
-        for (final PngText text : readTexts) {
-            if (text.keyword.equals("a")) {
-                assertEquals(text.text, "b");
-            } else if (text.keyword.equals("c")) {
-                assertEquals(text.text, "d");
-            } else if (text.keyword.equals("e")) {
-                assertEquals(text.text, "f");
-            } else {
-                fail("unknown text chunk.");
+            final List<PngText> readTexts = imageInfo.getTextChunks();
+            assertEquals(readTexts.size(), 3);
+            for (final PngText text : readTexts) {
+                if (text.keyword.equals("a")) {
+                    assertEquals(text.text, "b");
+                } else if (text.keyword.equals("c")) {
+                    assertEquals(text.text, "d");
+                } else if (text.keyword.equals("e")) {
+                    assertEquals(text.text, "f");
+                } else {
+                    fail("unknown text chunk.");
+                }
             }
+        } catch (final Throwable e) {
+            final File tempFile = Files.createTempFile("temp", ".png").toFile();
+            FileUtils.writeByteArrayToFile(tempFile, bytes);
         }
     }
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/FormatInfo.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/FormatInfo.java
@@ -130,4 +130,16 @@ class FormatInfo {
         this.identicalSecondWrite = identicalSecondWrite;
         this.preservesResolution = preservesResolution;
     }
+
+    @Override
+    public String toString() {
+        return "FormatInfo{" +
+            "format=" + format +
+            ", canRead=" + canRead +
+            ", canWrite=" + canWrite +
+            ", colorSupport=" + colorSupport +
+            ", identicalSecondWrite=" + identicalSecondWrite +
+            ", preservesResolution=" + preservesResolution +
+            '}';
+    }
 }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
@@ -99,4 +99,18 @@ final class ImageAsserts {
             Assertions.assertEquals(aByte, bByte);
         }
     }
+
+    static void assertEquals(byte[] aData, byte[] bData) {
+        for (int i = 0; i < aData.length; i++) {
+            final int aByte = 0xff & aData[i];
+            final int bByte = 0xff & bData[i];
+
+            if (aByte != bByte) {
+                Debug.debug("i: " + i);
+                Debug.debug("aByte: " + aByte + " (0x" + Integer.toHexString(aByte) + ')');
+                Debug.debug("bByte: " + bByte + " (0x" + Integer.toHexString(bByte) + ')');
+            }
+            Assertions.assertEquals(aByte, bByte);
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/NullParametersRoundtripTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,15 +40,26 @@ public class NullParametersRoundtripTest extends RoundtripBase {
     @MethodSource("data")
     public void testNullParametersRoundtrip(final FormatInfo formatInfo) throws Exception {
         final BufferedImage testImage = TestImages.createFullColorImage(1, 1);
-        final File temp1 = Files.createTempFile("nullParameters.", "." + formatInfo.format.getDefaultExtension()).toFile();
-        Imaging.writeImage(testImage, temp1, formatInfo.format);
-        Imaging.getImageInfo(temp1);
-        Imaging.getImageSize(temp1);
-        Imaging.getMetadata(temp1);
-        Imaging.getICCProfile(temp1);
-        final BufferedImage imageRead = Imaging.getBufferedImage(temp1);
+        final byte[] temp1;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(100000)) {
+            Imaging.writeImage(testImage, byteArrayOutputStream, formatInfo.format);
+            temp1 = byteArrayOutputStream.toByteArray();
+        }
+        try {
+            final String filename = "nullParameters." + formatInfo.format.getDefaultExtension();
+            Imaging.getImageInfo(new ByteArrayInputStream(temp1), filename);
+            Imaging.getImageSize(new ByteArrayInputStream(temp1), filename);
+            Imaging.getMetadata(new ByteArrayInputStream(temp1), filename);
+            Imaging.getICCProfile(new ByteArrayInputStream(temp1), filename);
+            final BufferedImage imageRead = Imaging.getBufferedImage(new ByteArrayInputStream(temp1), filename);
 
-        assertNotNull(imageRead);
+            assertNotNull(imageRead);
+        } catch (final Throwable e) {
+            final Path tempFile = Files.createTempFile("nullParameters.", '.' + formatInfo.format.getDefaultExtension());
+            Files.write(tempFile, temp1);
+            System.err.println("Failed tempFile " + tempFile);
+            throw e;
+        }
     }
 
 }


### PR DESCRIPTION
Same pull request as https://github.com/apache/commons-imaging/pull/271 but with squashed commits