### PR TITLE
[IMAGING-353] Fix PngImageParser hasPalette

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
@@ -496,7 +496,7 @@ public class PngImageParser extends ImageParser<PngImagingParameters>  implement
         boolean usesPalette = false;
 
         final List<PngChunk> PLTEs = filterChunks(chunks, ChunkType.PLTE);
-        if (PLTEs.size() > 1) {
+        if (!PLTEs.isEmpty()) {
             usesPalette = true;
         }
 


### PR DESCRIPTION
This PR makes sure the 'hasPalette' value is set correctly for PNG files.