### PR TITLE
[IMAGING-355] Large animated GIF takes too much heap memory in getMetadata

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -407,7 +407,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     @Override
     public ImageInfo getImageInfo(final ByteSource byteSource, final GifImagingParameters params)
             throws ImagingException, IOException {
-        final GifImageContents blocks = readFile(byteSource, false);
+        final GifImageContents blocks = readFile(byteSource, true);
 
         final GifHeaderInfo bhi = blocks.gifHeaderInfo;
         if (bhi == null) {
@@ -482,7 +482,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     @Override
     public ImageMetadata getMetadata(final ByteSource byteSource, final GifImagingParameters params)
             throws ImagingException, IOException {
-        final GifImageContents imageContents = readFile(byteSource, false);
+        final GifImageContents imageContents = readFile(byteSource, true);
 
         final GifHeaderInfo bhi = imageContents.gifHeaderInfo;
         if (bhi == null) {

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -407,7 +407,11 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     @Override
     public ImageInfo getImageInfo(final ByteSource byteSource, final GifImagingParameters params)
             throws ImagingException, IOException {
-        final GifImageContents blocks = readFile(byteSource, true);
+        boolean stopReadingBeforeImageData = true;
+        if (params != null) {
+            stopReadingBeforeImageData = params.getStopReadingBeforeImageData();
+        }
+        final GifImageContents blocks = readFile(byteSource, stopReadingBeforeImageData);
 
         final GifHeaderInfo bhi = blocks.gifHeaderInfo;
         if (bhi == null) {
@@ -482,7 +486,11 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     @Override
     public ImageMetadata getMetadata(final ByteSource byteSource, final GifImagingParameters params)
             throws ImagingException, IOException {
-        final GifImageContents imageContents = readFile(byteSource, true);
+        boolean stopReadingBeforeImageData = true;
+        if (params != null) {
+            stopReadingBeforeImageData = params.getStopReadingBeforeImageData();
+        }
+        final GifImageContents imageContents = readFile(byteSource, stopReadingBeforeImageData);
 
         final GifHeaderInfo bhi = imageContents.gifHeaderInfo;
         if (bhi == null) {

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImagingParameters.java
@@ -25,5 +25,13 @@ import org.apache.commons.imaging.common.XmpImagingParameters;
  * @since 1.0-alpha3
  */
 public class GifImagingParameters extends XmpImagingParameters<GifImagingParameters> {
-    // empty
+    private boolean stopReadingBeforeImageData;
+
+    public void setStopReadingBeforeImageData(boolean stopReadingBeforeImageData) {
+        this.stopReadingBeforeImageData = stopReadingBeforeImageData;
+    }
+
+    public boolean getStopReadingBeforeImageData() {
+        return stopReadingBeforeImageData;
+    }
 }

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImagingParameters.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImagingParameters.java
@@ -27,11 +27,12 @@ import org.apache.commons.imaging.common.XmpImagingParameters;
 public class GifImagingParameters extends XmpImagingParameters<GifImagingParameters> {
     private boolean stopReadingBeforeImageData;
 
-    public void setStopReadingBeforeImageData(boolean stopReadingBeforeImageData) {
-        this.stopReadingBeforeImageData = stopReadingBeforeImageData;
-    }
-
     public boolean getStopReadingBeforeImageData() {
         return stopReadingBeforeImageData;
     }
+
+    public void setStopReadingBeforeImageData(final boolean stopReadingBeforeImageData) {
+        this.stopReadingBeforeImageData = stopReadingBeforeImageData;
+    }
+
 }

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
@@ -139,11 +140,15 @@ public class GifReadTest extends GifBaseTest {
         // TODO assert more
     }
 
-    @Disabled(value = "RoundtripTest has to be fixed before implementation can throw UnsupportedOperationException")
     @ParameterizedTest
     @MethodSource("data")
-    public void testMetadata(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+    public void testMetadata(final File imageFile) throws IOException {
+        ImageMetadata metadata = Imaging.getMetadata(imageFile);
+        assertNotNull(metadata);
+        assertTrue(metadata instanceof GifImageMetadata);
+        assertTrue(((GifImageMetadata)metadata).getWidth() > 0);
+        assertTrue(((GifImageMetadata)metadata).getHeight() > 0);
+        assertNotNull(metadata.getItems());
     }
 
     /**

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -117,7 +117,7 @@ public class GifReadTest extends GifBaseTest {
 
         int width = 0;
         int height = 0;
-        for(int i = 0; i < images.size(); i++) {
+        for (int i = 0; i < images.size(); i++) {
             final BufferedImage image = images.get(i);
             final GifImageMetadataItem metadataItem = metadata.getItems().get(i);
             final int xOffset = metadataItem.getLeftPosition();
@@ -143,7 +143,7 @@ public class GifReadTest extends GifBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testMetadata(final File imageFile) throws IOException {
-        ImageMetadata metadata = Imaging.getMetadata(imageFile);
+        final ImageMetadata metadata = Imaging.getMetadata(imageFile);
         assertNotNull(metadata);
         assertTrue(metadata instanceof GifImageMetadata);
         assertTrue(((GifImageMetadata)metadata).getWidth() > 0);


### PR DESCRIPTION
IMAGING-355 - Large animated GIF takes too much heap memory in getMetadata