### PR TITLE
IMAGING-322: ImageFormat uses a list for extensions instead of array

### DIFF
--- a/src/main/java/org/apache/commons/imaging/ImageFormat.java
+++ b/src/main/java/org/apache/commons/imaging/ImageFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging;
 
+import java.util.List;
 
 /**
  * Simple image format interface.
@@ -27,9 +28,9 @@ public interface ImageFormat {
     /**
      * Gets the file extension associated with this {@link ImageFormat}.
      *
-     * @return String extension
+     * @return String extensions
      */
-    String[] getExtensions();
+    List<String> getExtensions();
 
     /**
      * Gets the name of this {@link ImageFormat}.

--- a/src/main/java/org/apache/commons/imaging/ImageFormats.java
+++ b/src/main/java/org/apache/commons/imaging/ImageFormats.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.imaging;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Enum of known image formats.
  */
@@ -43,24 +48,29 @@ public enum ImageFormats implements ImageFormat {
     XBM("xbm"),
     XPM("xpm");
 
-    private final String[] extensions;
+    private final List<String> extensions;
 
-    ImageFormats(final String ...extensions) {
-        this.extensions = extensions;
+    ImageFormats(final String... extensions) {
+        this.extensions = Arrays.stream(extensions).collect(Collectors.toList());
     }
 
     @Override
     public String getDefaultExtension() {
-        return this.extensions != null ? this.extensions[0] : null;
+        return this.extensions != null ? this.extensions.get(0) : null;
     }
 
     @Override
-    public String[] getExtensions() {
-        return this.extensions.clone();
+    public List<String> getExtensions() {
+        return new ArrayList<>(this.extensions);
     }
 
     @Override
     public String getName() {
         return name();
+    }
+
+
+    public static List<ImageFormats> valuesAsList() {
+        return Arrays.stream(values()).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/apache/commons/imaging/ImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/ImageParser.java
@@ -147,7 +147,7 @@ public abstract class ImageParser<T extends ImagingParameters<T>> extends Binary
      * @return If the parser can accept the format, true; otherwise, false.
      */
     public final boolean canAcceptExtension(final String fileName) {
-        final String[] extensions = getAcceptedExtensions();
+        final List<String> extensions = getAcceptedExtensions();
         if (extensions == null) {
             return true;
         }
@@ -265,7 +265,7 @@ public abstract class ImageParser<T extends ImagingParameters<T>> extends Binary
      *
      * @return A valid array of one or more elements.
      */
-    protected abstract String[] getAcceptedExtensions();
+    protected abstract List<String> getAcceptedExtensions();
 
     /**
      * Get an array of ImageFormat objects describing all accepted types

--- a/src/main/java/org/apache/commons/imaging/Imaging.java
+++ b/src/main/java/org/apache/commons/imaging/Imaging.java
@@ -756,8 +756,8 @@ public final class Imaging {
             }
             return Stream
                 .of(ImageFormats.values())
-                .filter(imageFormat -> Stream
-                    .of(imageFormat.getExtensions())
+                .filter(imageFormat -> imageFormat.getExtensions()
+                    .stream()
                     .anyMatch(extension -> {
                         final String fileName = byteSource.getFileName();
                         if (fileName == null || fileName.trim().isEmpty()) {

--- a/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/bmp/BmpImageParser.java
@@ -53,7 +53,7 @@ public class BmpImageParser extends ImageParser<BmpImagingParameters> {
     private static final Logger LOGGER = Logger.getLogger(BmpImageParser.class.getName());
 
     private static final String DEFAULT_EXTENSION = ImageFormats.BMP.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.BMP.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.BMP.getExtensions();
     private static final byte[] BMP_HEADER_SIGNATURE = { 0x42, 0x4d, };
     private static final int BI_RGB = 0;
     private static final int BI_RLE4 = 2;
@@ -81,7 +81,7 @@ public class BmpImageParser extends ImageParser<BmpImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -62,7 +62,7 @@ public class DcxImageParser extends ImageParser<PcxImagingParameters> {
     // See [BROEKN URL] http://www.fileformat.fine/format/pcx/egff.htm for documentation
     private static final String DEFAULT_EXTENSION = ImageFormats.DCX.getDefaultExtension();
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.DCX.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.DCX.getExtensions();
 
     public DcxImageParser() {
         super(ByteOrder.LITTLE_ENDIAN);
@@ -76,7 +76,7 @@ public class DcxImageParser extends ImageParser<PcxImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -60,7 +60,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     private static final Logger LOGGER = Logger.getLogger(GifImageParser.class.getName());
 
     private static final String DEFAULT_EXTENSION = ImageFormats.GIF.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.GIF.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.GIF.getExtensions();
     private static final byte[] GIF_HEADER_SIGNATURE = { 71, 73, 70 };
     private static final int EXTENSION_CODE = 0x21;
     private static final int IMAGE_SEPARATOR = 0x2C;
@@ -214,7 +214,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsImageParser.java
@@ -96,7 +96,7 @@ public class IcnsImageParser extends ImageParser<IcnsImagingParameters> {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.ICNS.getDefaultExtension();
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.ICNS.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.ICNS.getExtensions();
 
     @Override
     public boolean dumpImageFile(final PrintWriter pw, final ByteSource byteSource)
@@ -110,7 +110,7 @@ public class IcnsImageParser extends ImageParser<IcnsImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
@@ -232,7 +232,7 @@ public class IcoImageParser extends ImageParser<IcoImagingParameters> {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.ICO.getDefaultExtension();
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.ICO.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.ICO.getExtensions();
 
     public IcoImageParser() {
         super(ByteOrder.LITTLE_ENDIAN);
@@ -250,7 +250,7 @@ public class IcoImageParser extends ImageParser<IcoImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -67,7 +67,7 @@ public class JpegImageParser extends ImageParser<JpegImagingParameters> implemen
     private static final Logger LOGGER = Logger.getLogger(JpegImageParser.class.getName());
 
     private static final String DEFAULT_EXTENSION = ImageFormats.JPEG.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.JPEG.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.JPEG.getExtensions();
 
     public static boolean isExifApp1Segment(final GenericSegment segment) {
         return startsWith(segment.getSegmentData(), JpegConstants.EXIF_IDENTIFIER_CODE);
@@ -203,7 +203,7 @@ public class JpegImageParser extends ImageParser<JpegImagingParameters> implemen
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -38,6 +38,7 @@ import java.io.PrintWriter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.imaging.ImageFormat;
@@ -154,7 +155,7 @@ public class PcxImageParser extends ImageParser<PcxImagingParameters> {
     }
     private static final String DEFAULT_EXTENSION = ImageFormats.PCX.getDefaultExtension();
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.PCX.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.PCX.getExtensions();
 
     public PcxImageParser() {
         super(ByteOrder.LITTLE_ENDIAN);
@@ -168,7 +169,7 @@ public class PcxImageParser extends ImageParser<PcxImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
@@ -70,7 +70,7 @@ public class PngImageParser extends ImageParser<PngImagingParameters>  implement
     private static final Logger LOGGER = Logger.getLogger(PngImageParser.class.getName());
 
     private static final String DEFAULT_EXTENSION = ImageFormats.PNG.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.PNG.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.PNG.getExtensions();
 
     public static String getChunkTypeName(final int chunkType) {
         final StringBuilder result = new StringBuilder();
@@ -133,8 +133,8 @@ public class PngImageParser extends ImageParser<PngImagingParameters>  implement
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
-        return ACCEPTED_EXTENSIONS.clone();
+    protected List<String> getAcceptedExtensions() {
+        return new ArrayList<>(ACCEPTED_EXTENSIONS);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pnm/PnmImageParser.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -42,13 +43,13 @@ import org.apache.commons.imaging.palette.PaletteFactory;
 public class PnmImageParser extends ImageParser<PnmImagingParameters> {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.PNM.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = {
-            ImageFormats.PAM.getDefaultExtension(),
-            ImageFormats.PBM.getDefaultExtension(),
-            ImageFormats.PGM.getDefaultExtension(),
-            ImageFormats.PNM.getDefaultExtension(),
-            ImageFormats.PPM.getDefaultExtension()
-    };
+    private static final List<String> ACCEPTED_EXTENSIONS = Arrays.asList(
+                    ImageFormats.PAM.getDefaultExtension(),
+                    ImageFormats.PAM.getDefaultExtension(),
+                    ImageFormats.PBM.getDefaultExtension(),
+                    ImageFormats.PGM.getDefaultExtension(),
+                    ImageFormats.PNM.getDefaultExtension(),
+                    ImageFormats.PPM.getDefaultExtension());
 
     public PnmImageParser() {
         super(ByteOrder.LITTLE_ENDIAN);
@@ -72,7 +73,7 @@ public class PnmImageParser extends ImageParser<PnmImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/PsdImageParser.java
@@ -56,7 +56,7 @@ import org.apache.commons.imaging.formats.psd.datareaders.UncompressedDataReader
 public class PsdImageParser extends ImageParser<PsdImagingParameters> implements XmpEmbeddable {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.PSD.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.PSD.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.PSD.getExtensions();
     private static final int PSD_SECTION_HEADER = 0;
     private static final int PSD_SECTION_COLOR_MODE = 1;
     private static final int PSD_SECTION_IMAGE_RESOURCES = 2;
@@ -113,8 +113,8 @@ public class PsdImageParser extends ImageParser<PsdImagingParameters> implements
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
-        return ACCEPTED_EXTENSIONS.clone();
+    protected List<String> getAcceptedExtensions() {
+        return new ArrayList<>(ACCEPTED_EXTENSIONS);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeImageParser.java
@@ -28,7 +28,7 @@ import java.awt.image.DataBufferFloat;
 import java.awt.image.Raster;
 import java.io.IOException;
 import java.util.ArrayList;
-
+import java.util.List;
 import org.apache.commons.imaging.ImageFormat;
 import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.ImageInfo;
@@ -43,7 +43,7 @@ import org.apache.commons.imaging.common.ImageMetadata;
 public class RgbeImageParser extends ImageParser<RgbeImagingParameters> {
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ImageFormats.RGBE.getExtensions();
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -66,7 +66,7 @@ import org.apache.commons.imaging.formats.tiff.write.TiffImageWriterLossy;
 public class TiffImageParser extends ImageParser<TiffImagingParameters> implements XmpEmbeddable<TiffImagingParameters> {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.TIFF.getDefaultExtension();
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.TIFF.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.TIFF.getExtensions();
 
     private Rectangle checkForSubImage(
             final TiffImagingParameters params) {
@@ -159,7 +159,7 @@ public class TiffImageParser extends ImageParser<TiffImagingParameters> implemen
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/wbmp/WbmpImageParser.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.imaging.ImageFormat;
@@ -66,7 +67,7 @@ public class WbmpImageParser extends ImageParser<WbmpImagingParameters> {
     }
     private static final String DEFAULT_EXTENSION = ImageFormats.WBMP.getDefaultExtension();
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.WBMP.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.WBMP.getExtensions();
 
     @Override
     public boolean dumpImageFile(final PrintWriter pw, final ByteSource byteSource)
@@ -76,7 +77,7 @@ public class WbmpImageParser extends ImageParser<WbmpImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xbm/XbmImageParser.java
@@ -31,6 +31,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -76,7 +77,7 @@ public class XbmImageParser extends ImageParser<XbmImagingParameters> {
         BasicCParser cParser;
         XbmHeader xbmHeader;
     }
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.XBM.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.XBM.getExtensions();
 
     private static final String DEFAULT_EXTENSION = ImageFormats.XBM.getDefaultExtension();
 
@@ -124,7 +125,7 @@ public class XbmImageParser extends ImageParser<XbmImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 

--- a/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -122,7 +123,7 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
         XpmHeader xpmHeader;
     }
 
-    private static final String[] ACCEPTED_EXTENSIONS = ImageFormats.XPM.getExtensions();
+    private static final List<String> ACCEPTED_EXTENSIONS = ImageFormats.XPM.getExtensions();
     private static Map<String, Integer> colorNames;
 
     private static final String DEFAULT_EXTENSION = ImageFormats.XPM.getDefaultExtension();
@@ -176,7 +177,7 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
     }
 
     @Override
-    protected String[] getAcceptedExtensions() {
+    protected List<String> getAcceptedExtensions() {
         return ACCEPTED_EXTENSIONS;
     }
 


### PR DESCRIPTION
[IMAGING-322](https://issues.apache.org/jira/browse/IMAGING-322): ImageFormat uses a list for extensions instead of array