### PR TITLE
Make checkForSubImage null-safe

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -75,7 +75,7 @@ public class TiffImageParser extends ImageParser<TiffImagingParameters> implemen
         // dimensions of the image that is being read.  This method
         // returns the sub-image specification, if any, and leaves
         // further tests to the calling module.
-        if (params.isSubImageSet()) {
+        if (params != null && params.isSubImageSet()) {
             final int ix0 = params.getSubImageX();
             final int iy0 = params.getSubImageY();
             final int iwidth = params.getSubImageWidth();


### PR DESCRIPTION
Make checkForSubImage null-safe for TiffImagingParameters params.
Especially as params gets set as null in TiffImageParser.java:183 getAllBufferedImages()