### PR TITLE
[IMAGING-359] Fix test resource file paths not being constructed properly

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpImageParserTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,8 +40,7 @@ public class BmpImageParserTest {
      */
     @Test
     public void testImageForNegativeArraySizeException() throws ImagingException, IOException {
-        final String file = "/images/bmp/IMAGING-279/negative_array_size_exception.bmp";
-        final File bmp = new File(BmpImageParser.class.getResource(file).getFile());
+        final File bmp = fileResource("/images/bmp/IMAGING-279/negative_array_size_exception.bmp");
         final BmpImageParser parser = new BmpImageParser();
         assertThrows(IllegalArgumentException.class, () -> parser.getImageInfo(bmp, new BmpImagingParameters()));
     }
@@ -52,8 +52,7 @@ public class BmpImageParserTest {
      */
     @Test
     public void testImageWidthRounding() throws ImagingException, IOException {
-        final String file = "/images/bmp/IMAGING-264/test-72_6-dpi.bmp";
-        final File bmp = new File(BmpImageParser.class.getResource(file).getFile());
+        final File bmp = fileResource("/images/bmp/IMAGING-264/test-72_6-dpi.bmp");
         final BmpImageParser parser = new BmpImageParser();
         final ImageInfo imageInfo = parser.getImageInfo(bmp, new BmpImagingParameters());
         assertEquals(73, imageInfo.getPhysicalWidthDpi(), "Expected 72.6 resolution to be rounded to 73");

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpImageParserTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,6 +24,7 @@ import java.io.IOException;
 
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.ImagingException;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,7 +40,7 @@ public class BmpImageParserTest {
      */
     @Test
     public void testImageForNegativeArraySizeException() throws ImagingException, IOException {
-        final File bmp = fileResource("/images/bmp/IMAGING-279/negative_array_size_exception.bmp");
+        final File bmp = TestResources.fileResource("/images/bmp/IMAGING-279/negative_array_size_exception.bmp");
         final BmpImageParser parser = new BmpImageParser();
         assertThrows(IllegalArgumentException.class, () -> parser.getImageInfo(bmp, new BmpImagingParameters()));
     }
@@ -52,7 +52,7 @@ public class BmpImageParserTest {
      */
     @Test
     public void testImageWidthRounding() throws ImagingException, IOException {
-        final File bmp = fileResource("/images/bmp/IMAGING-264/test-72_6-dpi.bmp");
+        final File bmp = TestResources.fileResource("/images/bmp/IMAGING-264/test-72_6-dpi.bmp");
         final BmpImageParser parser = new BmpImageParser();
         final ImageInfo imageInfo = parser.getImageInfo(bmp, new BmpImagingParameters());
         assertEquals(73, imageInfo.getPhysicalWidthDpi(), "Expected 72.6 resolution to be rounded to 73");

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -80,9 +81,7 @@ public class BmpReadTest extends BmpBaseTest {
 
     @Test
     public void testNegativePaletteLength() {
-        final String input = "/images/bmp/IMAGING-325/crash-3afb569de74522535ef65922233e1920455cdc14.bmp";
-        final String location = BmpReadTest.class.getResource(input).getFile();
-        final File inputFile = new File(location);
+        final File inputFile = fileResource("/images/bmp/IMAGING-325/crash-3afb569de74522535ef65922233e1920455cdc14.bmp");
         assertThrows(ImagingException.class, () -> new BmpImageParser().dumpImageFile(ByteSource.file(inputFile)));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.imaging.formats.bmp;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -30,6 +29,7 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.ImagingTestConstants;
 import org.apache.commons.imaging.bytesource.ByteSource;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -80,7 +80,7 @@ public class BmpReadTest extends BmpBaseTest {
 
     @Test
     public void testNegativePaletteLength() {
-        final File inputFile = fileResource("/images/bmp/IMAGING-325/crash-3afb569de74522535ef65922233e1920455cdc14.bmp");
+        final File inputFile = TestResources.fileResource("/images/bmp/IMAGING-325/crash-3afb569de74522535ef65922233e1920455cdc14.bmp");
         assertThrows(ImagingException.class, () -> new BmpImageParser().dumpImageFile(ByteSource.file(inputFile)));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.imaging.formats.gif;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,6 +32,7 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -159,7 +159,7 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33464() throws IOException {
-        final File file = fileResource("/images/gif/oss-fuzz-33464/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5174009164595200");
+        final File file = TestResources.fileResource("/images/gif/oss-fuzz-33464/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5174009164595200");
         final GifImageParser parser = new GifImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }
@@ -175,7 +175,7 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33501() throws IOException {
-        final File file = fileResource("/images/gif/oss-fuzz-33501/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5914278319226880");
+        final File file = TestResources.fileResource("/images/gif/oss-fuzz-33501/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5914278319226880");
         final GifImageParser parser = new GifImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }
@@ -189,7 +189,7 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz34185() throws IOException {
-        final File file = fileResource("/images/gif/IMAGING-318/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5005192379629568");
+        final File file = TestResources.fileResource("/images/gif/IMAGING-318/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5005192379629568");
         final GifImageParser parser = new GifImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.gif;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -159,10 +160,9 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33464() throws IOException {
-        final String input = "/images/gif/oss-fuzz-33464/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5174009164595200";
-        final String file = GifReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/gif/oss-fuzz-33464/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5174009164595200");
         final GifImageParser parser = new GifImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new GifImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }
 
     /**
@@ -176,10 +176,9 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33501() throws IOException {
-        final String input = "/images/gif/oss-fuzz-33501/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5914278319226880";
-        final String file = GifReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/gif/oss-fuzz-33501/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5914278319226880");
         final GifImageParser parser = new GifImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new GifImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }
 
     /**
@@ -191,9 +190,8 @@ public class GifReadTest extends GifBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz34185() throws IOException {
-        final String input = "/images/gif/IMAGING-318/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5005192379629568";
-        final String file = GifReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/gif/IMAGING-318/clusterfuzz-testcase-minimized-ImagingGifFuzzer-5005192379629568");
         final GifImageParser parser = new GifImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new GifImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new GifImagingParameters()));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.imaging.formats.icns;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,6 +31,7 @@ import java.util.stream.Stream;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -77,7 +77,7 @@ public class IcnsReadTest extends IcnsBaseTest {
     @ParameterizedTest()
     @MethodSource("provideIcnsImagesWithMonoAndJpegPngData")
     public void testIcnsElementMonoPngJpeg(final String file, final int numberOfImages) throws ImagingException, IOException {
-        final File testFile = fileResource(file);
+        final File testFile = TestResources.fileResource(file);
         final List<BufferedImage> images = new IcnsImageParser().getAllBufferedImages(testFile);
         assertEquals(numberOfImages, images.size());
     }

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.icns;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -76,7 +77,7 @@ public class IcnsReadTest extends IcnsBaseTest {
     @ParameterizedTest()
     @MethodSource("provideIcnsImagesWithMonoAndJpegPngData")
     public void testIcnsElementMonoPngJpeg(final String file, final int numberOfImages) throws ImagingException, IOException {
-        final File testFile = new File(IcnsReadTest.class.getResource(file).getFile());
+        final File testFile = fileResource(file);
         final List<BufferedImage> images = new IcnsImageParser().getAllBufferedImages(testFile);
         assertEquals(numberOfImages, images.size());
     }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,6 +32,7 @@ import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.formats.tiff.TiffImagingParameters;
 import org.apache.commons.imaging.internal.Debug;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -77,7 +77,7 @@ public class JpegReadTest extends JpegBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33458() {
-        final File file = fileResource("/images/jpeg/oss-fuzz-33458/clusterfuzz-testcase-minimized-ImagingJpegFuzzer-4548690447564800");
+        final File file = TestResources.fileResource("/images/jpeg/oss-fuzz-33458/clusterfuzz-testcase-minimized-ImagingJpegFuzzer-4548690447564800");
         final JpegImageParser parser = new JpegImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new JpegImagingParameters()));
     }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,10 +77,9 @@ public class JpegReadTest extends JpegBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33458() {
-        final String input = "/images/jpeg/oss-fuzz-33458/clusterfuzz-testcase-minimized-ImagingJpegFuzzer-4548690447564800";
-        final String file = JpegReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/jpeg/oss-fuzz-33458/clusterfuzz-testcase-minimized-ImagingJpegFuzzer-4548690447564800");
         final JpegImageParser parser = new JpegImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new JpegImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new JpegImagingParameters()));
     }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,7 +36,7 @@ public class JpegWithInvalidDhtSegmentTest {
     public void testSingleImage() {
         // we cannot use ImagingTest and getImageByFileName, as it would cause others
         // tests to fail
-        final File imageFile = fileResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg");
+        final File imageFile = TestResources.fileResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg");
         assertThrows(ImagingException.class, () -> Imaging.getMetadata(imageFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,9 +36,7 @@ public class JpegWithInvalidDhtSegmentTest {
     public void testSingleImage() {
         // we cannot use ImagingTest and getImageByFileName, as it would cause others
         // tests to fail
-        final File imageFile = new File(JpegWithInvalidDhtSegmentTest.class
-                .getResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg")
-                .getFile());
-        Assertions.assertThrows(ImagingException.class, () -> Imaging.getMetadata(imageFile));
+        final File imageFile = fileResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg");
+        assertThrows(ImagingException.class, () -> Imaging.getMetadata(imageFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.commons.imaging.formats.jpeg.decoder;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,10 +37,8 @@ public class JpegDecoderTest {
     @Test
     public void testDecodeBadFile() {
         // From IMAGING-220
-        final File inputFile = new File(
-                JpegDecoderTest.class.getResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg")
-                        .getFile());
+        final File inputFile = fileResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg");
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
-        Assertions.assertThrows(ImagingException.class, () -> new JpegDecoder().decode(byteSourceFile));
+        assertThrows(ImagingException.class, () -> new JpegDecoder().decode(byteSourceFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.imaging.formats.jpeg.decoder;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,7 +37,7 @@ public class JpegDecoderTest {
     @Test
     public void testDecodeBadFile() {
         // From IMAGING-220
-        final File inputFile = fileResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg");
+        final File inputFile = TestResources.fileResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg");
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
         assertThrows(ImagingException.class, () -> new JpegDecoder().decode(byteSourceFile));
     }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,6 +33,7 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegImagingParameters;
 import org.apache.commons.imaging.formats.jpeg.JpegPhotoshopMetadata;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,7 +50,7 @@ public class IptcParserTest {
     @Test
     public void testEncodingSupport() throws IOException, ImagingException {
         // NOTE: We use the JpegParser, so it will send only the block/segment that IptcParser needs for the test image
-        final File file = fileResource("/images/jpeg/iptc/IMAGING-168/111083453-c07f1880-851e-11eb-8b61-2757f7d934bf.jpg");
+        final File file = TestResources.fileResource("/images/jpeg/iptc/IMAGING-168/111083453-c07f1880-851e-11eb-8b61-2757f7d934bf.jpg");
         final JpegImageParser parser = new JpegImageParser();
         final JpegImageMetadata metadata = (JpegImageMetadata) parser.getMetadata(file);
         final JpegPhotoshopMetadata photoshopMetadata = metadata.getPhotoshop();
@@ -82,7 +82,7 @@ public class IptcParserTest {
      */
     @Test
     public void testSkipBlockTypes() throws ImagingException, IOException {
-        final File imageFile = fileResource("/images/jpeg/photoshop/IMAGING-246/FallHarvestKitKat_07610.jpg");
+        final File imageFile = TestResources.fileResource("/images/jpeg/photoshop/IMAGING-246/FallHarvestKitKat_07610.jpg");
         final JpegImageMetadata metadata = (JpegImageMetadata) new JpegImageParser()
                 .getMetadata(ByteSource.file(imageFile), new JpegImagingParameters());
         final JpegPhotoshopMetadata photoshopMetadata = metadata.getPhotoshop();

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +50,7 @@ public class IptcParserTest {
     @Test
     public void testEncodingSupport() throws IOException, ImagingException {
         // NOTE: We use the JpegParser, so it will send only the block/segment that IptcParser needs for the test image
-        final File file = new File(IptcParserTest.class.getResource("/images/jpeg/iptc/IMAGING-168/111083453-c07f1880-851e-11eb-8b61-2757f7d934bf.jpg").getFile());
+        final File file = fileResource("/images/jpeg/iptc/IMAGING-168/111083453-c07f1880-851e-11eb-8b61-2757f7d934bf.jpg");
         final JpegImageParser parser = new JpegImageParser();
         final JpegImageMetadata metadata = (JpegImageMetadata) parser.getMetadata(file);
         final JpegPhotoshopMetadata photoshopMetadata = metadata.getPhotoshop();
@@ -81,10 +82,7 @@ public class IptcParserTest {
      */
     @Test
     public void testSkipBlockTypes() throws ImagingException, IOException {
-        final String location = IptcParserTest.class
-                .getResource("/images/jpeg/photoshop/IMAGING-246/FallHarvestKitKat_07610.jpg")
-                .getFile();
-        final File imageFile = new File(location);
+        final File imageFile = fileResource("/images/jpeg/photoshop/IMAGING-246/FallHarvestKitKat_07610.jpg");
         final JpegImageMetadata metadata = (JpegImageMetadata) new JpegImageParser()
                 .getMetadata(ByteSource.file(imageFile), new JpegImagingParameters());
         final JpegPhotoshopMetadata photoshopMetadata = metadata.getPhotoshop();

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
@@ -16,7 +16,6 @@
 
 package org.apache.commons.imaging.formats.jpeg.specific;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
@@ -26,6 +25,7 @@ import java.io.IOException;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,7 +39,7 @@ public class JpegImageParserTest {
      */
     @Test
     public void testGetBufferedImage10() throws ImagingException, IOException {
-        final File imageFile = fileResource("/IMAGING-136/1402522741337.jpg");
+        final File imageFile = TestResources.fileResource("/IMAGING-136/1402522741337.jpg");
         final JpegImageParser parser = new JpegImageParser();
         final BufferedImage image = parser.getBufferedImage(ByteSource.file(imageFile), null);
         assertEquals(680, image.getWidth());

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/specific/JpegImageParserTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.commons.imaging.formats.jpeg.specific;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
@@ -25,7 +26,6 @@ import java.io.IOException;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
-import org.apache.commons.imaging.formats.jpeg.decoder.JpegDecoderTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,9 +39,7 @@ public class JpegImageParserTest {
      */
     @Test
     public void testGetBufferedImage10() throws ImagingException, IOException {
-        final File imageFile = new File(
-                JpegDecoderTest.class.getResource("/IMAGING-136/1402522741337.jpg")
-                .getFile());
+        final File imageFile = fileResource("/IMAGING-136/1402522741337.jpg");
         final JpegImageParser parser = new JpegImageParser();
         final BufferedImage image = parser.getBufferedImage(ByteSource.file(imageFile), null);
         assertEquals(680, image.getWidth());

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.png;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -88,11 +89,10 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testReadMetadataFromItxtChunk() throws IOException, ImagingException {
-        final String input = "/images/png/IMAGING-342/utf8-comment.png";
-        final String file = PngReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/png/IMAGING-342/utf8-comment.png");
         final PngImageParser parser = new PngImageParser();
 
-        final ImageMetadata metadata = parser.getMetadata(new File(file));
+        final ImageMetadata metadata = parser.getMetadata(file);
         final List<?> items = metadata.getItems();
         assertEquals(1, items.size());
 
@@ -112,10 +112,9 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33691() throws IOException {
-        final String input = "/images/png/oss-fuzz-33691/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6177282101215232";
-        final String file = PngReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/png/oss-fuzz-33691/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6177282101215232");
         final PngImageParser parser = new PngImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new PngImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new PngImagingParameters()));
     }
 
     /**
@@ -128,9 +127,8 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz37607() throws IOException {
-        final String input = "/images/png/IMAGING-317/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6242400830357504";
-        final String file = PngReadTest.class.getResource(input).getFile();
+        final File file = fileResource("/images/png/IMAGING-317/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6242400830357504");
         final PngImageParser parser = new PngImageParser();
-        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(new File(file)), new PngImagingParameters()));
+        assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new PngImagingParameters()));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,6 +34,7 @@ import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 public class PngReadTest extends PngBaseTest {
@@ -89,7 +89,7 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testReadMetadataFromItxtChunk() throws IOException, ImagingException {
-        final File file = fileResource("/images/png/IMAGING-342/utf8-comment.png");
+        final File file = TestResources.fileResource("/images/png/IMAGING-342/utf8-comment.png");
         final PngImageParser parser = new PngImageParser();
 
         final ImageMetadata metadata = parser.getMetadata(file);
@@ -112,7 +112,7 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz33691() throws IOException {
-        final File file = fileResource("/images/png/oss-fuzz-33691/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6177282101215232");
+        final File file = TestResources.fileResource("/images/png/oss-fuzz-33691/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6177282101215232");
         final PngImageParser parser = new PngImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new PngImagingParameters()));
     }
@@ -127,7 +127,7 @@ public class PngReadTest extends PngBaseTest {
      */
     @Test
     public void testUncaughtExceptionOssFuzz37607() throws IOException {
-        final File file = fileResource("/images/png/IMAGING-317/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6242400830357504");
+        final File file = TestResources.fileResource("/images/png/IMAGING-317/clusterfuzz-testcase-minimized-ImagingPngFuzzer-6242400830357504");
         final PngImageParser parser = new PngImageParser();
         assertThrows(ImagingException.class, () -> parser.getBufferedImage(ByteSource.file(file), new PngImagingParameters()));
     }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.commons.imaging.formats.png;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.examples.ImageReadExample.ManagedImageBufferedImageFactory;
-import org.apache.commons.imaging.formats.jpeg.JpegWithInvalidDhtSegmentTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,12 +37,11 @@ public class PngWithInvalidPngChunkSizeTest {
      */
     @Test
     public void testPngWithInvalidNegativePngChunkSize() {
-        final File imageFile = new File(
-                JpegWithInvalidDhtSegmentTest.class.getResource("/IMAGING-210/testfile.png").getFile());
+        final File imageFile = fileResource("/IMAGING-210/testfile.png");
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
+        assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
     }
 
     /**
@@ -50,10 +50,10 @@ public class PngWithInvalidPngChunkSizeTest {
      */
     @Test
     public void testPngWithInvalidPngChunkSize() {
-        final File imageFile = new File(JpegWithInvalidDhtSegmentTest.class.getResource("/IMAGING-211/testfile_2.png").getFile());
+        final File imageFile = fileResource("/IMAGING-211/testfile_2.png");
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
+        assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.imaging.formats.png;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.examples.ImageReadExample.ManagedImageBufferedImageFactory;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,7 +37,7 @@ public class PngWithInvalidPngChunkSizeTest {
      */
     @Test
     public void testPngWithInvalidNegativePngChunkSize() {
-        final File imageFile = fileResource("/IMAGING-210/testfile.png");
+        final File imageFile = TestResources.fileResource("/IMAGING-210/testfile.png");
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();
@@ -50,7 +50,7 @@ public class PngWithInvalidPngChunkSizeTest {
      */
     @Test
     public void testPngWithInvalidPngChunkSize() {
-        final File imageFile = fileResource("/IMAGING-211/testfile_2.png");
+        final File imageFile = TestResources.fileResource("/IMAGING-211/testfile_2.png");
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();

--- a/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.imaging.formats.rgbe;
 
+import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -29,7 +31,6 @@ import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RgbeReadTest extends RgbeBaseTest {
@@ -61,11 +62,9 @@ public class RgbeReadTest extends RgbeBaseTest {
     @Test
     public void testErrorDecompressingInvalidFile() {
         // From IMAGING-219
-        final File inputFile = new File(
-                RgbeReadTest.class.getResource("/IMAGING-219/timeout-9713502c9c371f1654b493650c16ab17c0444369.hdr")
-                        .getFile());
+        final File inputFile = fileResource("/IMAGING-219/timeout-9713502c9c371f1654b493650c16ab17c0444369.hdr");
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
         final RgbeImagingParameters params = new RgbeImagingParameters();
-        Assertions.assertThrows(ImagingException.class, () -> new RgbeImageParser().getBufferedImage(byteSourceFile, params));
+        assertThrows(ImagingException.class, () -> new RgbeImageParser().getBufferedImage(byteSourceFile, params));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.imaging.formats.rgbe;
 
-import static org.apache.commons.imaging.test.TestResources.fileResource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -31,6 +30,7 @@ import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
+import org.apache.commons.imaging.test.TestResources;
 import org.junit.jupiter.api.Test;
 
 public class RgbeReadTest extends RgbeBaseTest {
@@ -62,7 +62,7 @@ public class RgbeReadTest extends RgbeBaseTest {
     @Test
     public void testErrorDecompressingInvalidFile() {
         // From IMAGING-219
-        final File inputFile = fileResource("/IMAGING-219/timeout-9713502c9c371f1654b493650c16ab17c0444369.hdr");
+        final File inputFile = TestResources.fileResource("/IMAGING-219/timeout-9713502c9c371f1654b493650c16ab17c0444369.hdr");
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
         final RgbeImagingParameters params = new RgbeImagingParameters();
         assertThrows(ImagingException.class, () -> new RgbeImageParser().getBufferedImage(byteSourceFile, params));

--- a/src/test/java/org/apache/commons/imaging/test/TestResources.java
+++ b/src/test/java/org/apache/commons/imaging/test/TestResources.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Helper class which provides convenience methods for accessing test resources.
+ */
+public class TestResources {
+    private TestResources() {
+    }
+
+    private static URI resourceUri(String path) {
+        URL url = TestResources.class.getResource(path);
+        if (url == null) {
+            throw new IllegalArgumentException("Resource does not exist: " + path);
+        }
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Gets a {@link File} for a {@linkplain Class#getResource(String) resource path}.
+     */
+    public static File fileResource(String path) {
+        return new File(resourceUri(path));
+    }
+
+    /**
+     * Gets a {@link Path} for a {@linkplain Class#getResource(String) resource path}.
+     */
+    public static Path pathResource(String path) {
+        return Paths.get(resourceUri(path));
+    }
+}


### PR DESCRIPTION
Using `URL.getFile()` is faulty because its result is URL encoded. This caused test failures when running in a directory with spaces in its file path.