### PR TITLE
Use static imports for JUnit Assertions methods

### DIFF
--- a/src/test/java/org/apache/commons/imaging/bytesource/ByteSourceTest.java
+++ b/src/test/java/org/apache/commons/imaging/bytesource/ByteSourceTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.imaging.bytesource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,7 +29,6 @@ import java.nio.file.Files;
 
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.ImagingTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public abstract class ByteSourceTest extends ImagingTest {
@@ -71,7 +71,7 @@ public abstract class ByteSourceTest extends ImagingTest {
 
     @Test
     public void testGetInputStreamThrowsNullPointerException() {
-        Assertions.assertThrows(NullPointerException.class, () -> ByteSource.array(null));
+        assertThrows(NullPointerException.class, () -> ByteSource.array(null));
     }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpReadTest.java
@@ -29,7 +29,6 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.ImagingTestConstants;
 import org.apache.commons.imaging.bytesource.ByteSource;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,7 +74,7 @@ public class BmpReadTest extends BmpBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testMetaData(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/dcx/DcxReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/dcx/DcxReadTest.java
@@ -18,13 +18,13 @@
 package org.apache.commons.imaging.formats.dcx;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -54,7 +54,7 @@ public class DcxReadTest extends DcxBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testImageMetadata(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
     }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/gif/GifReadTest.java
@@ -32,7 +32,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -76,7 +75,7 @@ public class GifReadTest extends GifBaseTest {
 
     @Test
     public void testConvertInvalidDisposalMethodValues() {
-        Assertions.assertThrows(ImagingException.class, () -> GifImageParser.createDisposalMethodFromIntValue(8));
+        assertThrows(ImagingException.class, () -> GifImageParser.createDisposalMethodFromIntValue(8));
     }
 
     @Test
@@ -89,21 +88,21 @@ public class GifReadTest extends GifBaseTest {
         final DisposalMethod toBeDefined2 = GifImageParser.createDisposalMethodFromIntValue(5);
         final DisposalMethod toBeDefined3 = GifImageParser.createDisposalMethodFromIntValue(6);
         final DisposalMethod toBeDefined4 = GifImageParser.createDisposalMethodFromIntValue(7);
-        Assertions.assertEquals(unspecified, DisposalMethod.UNSPECIFIED);
-        Assertions.assertEquals(doNotDispose, DisposalMethod.DO_NOT_DISPOSE);
-        Assertions.assertEquals(restoreToBackground, DisposalMethod.RESTORE_TO_BACKGROUND);
-        Assertions.assertEquals(restoreToPrevious, DisposalMethod.RESTORE_TO_PREVIOUS);
-        Assertions.assertEquals(toBeDefined1, DisposalMethod.TO_BE_DEFINED_1);
-        Assertions.assertEquals(toBeDefined2, DisposalMethod.TO_BE_DEFINED_2);
-        Assertions.assertEquals(toBeDefined3, DisposalMethod.TO_BE_DEFINED_3);
-        Assertions.assertEquals(toBeDefined4, DisposalMethod.TO_BE_DEFINED_4);
+        assertEquals(unspecified, DisposalMethod.UNSPECIFIED);
+        assertEquals(doNotDispose, DisposalMethod.DO_NOT_DISPOSE);
+        assertEquals(restoreToBackground, DisposalMethod.RESTORE_TO_BACKGROUND);
+        assertEquals(restoreToPrevious, DisposalMethod.RESTORE_TO_PREVIOUS);
+        assertEquals(toBeDefined1, DisposalMethod.TO_BE_DEFINED_1);
+        assertEquals(toBeDefined2, DisposalMethod.TO_BE_DEFINED_2);
+        assertEquals(toBeDefined3, DisposalMethod.TO_BE_DEFINED_3);
+        assertEquals(toBeDefined4, DisposalMethod.TO_BE_DEFINED_4);
     }
 
     @Test
     public void testCreateMetadataWithDisposalMethods() {
         for(final DisposalMethod disposalMethod : DisposalMethod.values()) {
             final GifImageMetadataItem metadataItem = new GifImageMetadataItem(0, 0, 0, disposalMethod);
-            Assertions.assertEquals(disposalMethod, metadataItem.getDisposalMethod());
+            assertEquals(disposalMethod, metadataItem.getDisposalMethod());
         }
     }
 
@@ -143,7 +142,7 @@ public class GifReadTest extends GifBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testMetadata(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
     }
 
     /**

--- a/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/icns/IcnsReadTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.imaging.formats.icns;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -30,7 +31,6 @@ import java.util.stream.Stream;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -92,6 +92,6 @@ public class IcnsReadTest extends IcnsBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testImageMetadata(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/ico/IcoReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/ico/IcoReadTest.java
@@ -18,13 +18,13 @@
 package org.apache.commons.imaging.formats.ico;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.stream.Stream;
 
 import org.apache.commons.imaging.Imaging;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,13 +47,13 @@ public class IcoReadTest extends IcoBaseTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testImageInfo(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getImageInfo(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getImageInfo(imageFile));
     }
 
     @Disabled(value = "RoundtripTest has to be fixed before implementation can throw UnsupportedOperationException")
     @ParameterizedTest
     @MethodSource("data")
     public void testMetadata(final File imageFile) {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(UnsupportedOperationException.class, () -> Imaging.getMetadata(imageFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/JpegWithInvalidDhtSegmentTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.commons.imaging.formats.jpeg;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,6 +38,6 @@ public class JpegWithInvalidDhtSegmentTest {
         final File imageFile = new File(JpegWithInvalidDhtSegmentTest.class
                 .getResource("/IMAGING-215/ArrayIndexOutOfBoundsException_DhtSegment_79.jpeg")
                 .getFile());
-        Assertions.assertThrows(ImagingException.class, () -> Imaging.getMetadata(imageFile));
+        assertThrows(ImagingException.class, () -> Imaging.getMetadata(imageFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoderTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.commons.imaging.formats.jpeg.decoder;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,6 +40,6 @@ public class JpegDecoderTest {
                 JpegDecoderTest.class.getResource("/IMAGING-220/timeout-48eb4251935b4ca8b26d1859ea525c1b42ae0c78.jpeg")
                         .getFile());
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
-        Assertions.assertThrows(ImagingException.class, () -> new JpegDecoder().decode(byteSourceFile));
+        assertThrows(ImagingException.class, () -> new JpegDecoder().decode(byteSourceFile));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegInputStreamTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegInputStreamTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.commons.imaging.formats.jpeg.decoder;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +34,7 @@ public class JpegInputStreamTest {
     byteArray[1] = (byte) 74;
     final JpegInputStream jpegInputStream = new JpegInputStream(byteArray);
 
-    Assertions.assertThrows(ImagingException.class, jpegInputStream::nextBit);
+    assertThrows(ImagingException.class, jpegInputStream::nextBit);
 
   }
 
@@ -42,7 +43,7 @@ public class JpegInputStreamTest {
     final int[] byteArray = {};
     final JpegInputStream jpegInputStream = new JpegInputStream(byteArray);
 
-    Assertions.assertThrows(IllegalStateException.class, jpegInputStream::nextBit);
+    assertThrows(IllegalStateException.class, jpegInputStream::nextBit);
 
   }
 

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriteTest.java
@@ -46,7 +46,6 @@ import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.apache.commons.imaging.formats.tiff.fieldtypes.FieldType;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ExifRewriteTest extends ExifBaseTest {
@@ -336,7 +335,7 @@ public class ExifRewriteTest extends ExifBaseTest {
 
             {
                 final JpegImageMetadata metadata = (JpegImageMetadata) Imaging.getMetadata(imageFile);
-                Assertions.assertNotNull(metadata);
+                assertNotNull(metadata);
             }
 
             {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriterRoundtripTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/ExifRewriterRoundtripTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.imaging.formats.jpeg.exif;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,7 +37,6 @@ import org.apache.commons.imaging.formats.tiff.write.TiffOutputField;
 import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,25 +56,25 @@ public class ExifRewriterRoundtripTest extends ExifBaseTest {
 
     private File duplicateFile;
 
-    private void assertEquals(final TiffOutputSet tiffOutputSet, final TiffOutputSet tiffOutputSet1) {
+    private void assertTiffEquals(final TiffOutputSet tiffOutputSet, final TiffOutputSet tiffOutputSet1) {
         final List<TiffOutputDirectory> directories = tiffOutputSet.getDirectories();
         final List<TiffOutputDirectory> directories1 = tiffOutputSet1.getDirectories();
-        Assertions.assertEquals(directories.size(), directories1.size(),
+        assertEquals(directories.size(), directories1.size(),
                 "The TiffOutputSets have different numbers of directories.");
 
         for (int i = 0; i < directories.size(); i++) {
             final List<TiffOutputField> fields = directories.get(i).getFields();
             final List<TiffOutputField> fields1 = directories1.get(i).getFields();
-            Assertions.assertEquals(fields.size(), fields1.size(),
+            assertEquals(fields.size(), fields1.size(),
                     "The TiffOutputDirectories have different numbers of fields.");
 
             for (int j = 0; j < fields.size(); j++) {
                 final TiffOutputField field = fields.get(j);
                 final TiffOutputField field1 = fields1.get(j);
-                Assertions.assertEquals(field.tag, field1.tag, "TiffOutputField tag mismatch.");
-                Assertions.assertEquals(field.tagInfo, field1.tagInfo, "TiffOutputField tagInfo mismatch.");
-                Assertions.assertEquals(field.fieldType, field1.fieldType, "TiffOutputField fieldType mismatch.");
-                Assertions.assertEquals(field.count, field1.count, "TiffOutputField count mismatch.");
+                assertEquals(field.tag, field1.tag, "TiffOutputField tag mismatch.");
+                assertEquals(field.tagInfo, field1.tagInfo, "TiffOutputField tagInfo mismatch.");
+                assertEquals(field.fieldType, field1.fieldType, "TiffOutputField fieldType mismatch.");
+                assertEquals(field.count, field1.count, "TiffOutputField count mismatch.");
             }
         }
     }
@@ -165,13 +166,13 @@ public class ExifRewriterRoundtripTest extends ExifBaseTest {
          */
         final List<? extends ImageMetadata.ImageMetadataItem> imageMetadataItems = sourceTiffImageMetadata.getItems();
         final List<? extends ImageMetadata.ImageMetadataItem> imageMetadataItems1 = duplicateTiffImageMetadata.getItems();
-        Assertions.assertEquals(imageMetadataItems.size(), imageMetadataItems1.size(),
+        assertEquals(imageMetadataItems.size(), imageMetadataItems1.size(),
                 "The TiffImageMetadata have different numbers of imageMetadataItems.");
 
         for (int i = 0; i < imageMetadataItems.size(); i++) {
             final ImageMetadata.ImageMetadataItem imageMetadataItem = imageMetadataItems.get(i);
             final ImageMetadata.ImageMetadataItem imageMetadataItem1 = imageMetadataItems1.get(i);
-            Assertions.assertEquals(imageMetadataItem.toString(), imageMetadataItem1.toString(),
+            assertEquals(imageMetadataItem.toString(), imageMetadataItem1.toString(),
                     "ImageMetadataItem toString mismatch.");
         }
     }
@@ -195,7 +196,7 @@ public class ExifRewriterRoundtripTest extends ExifBaseTest {
         /*
          * Compare the two TiffOutputSets
          */
-        assertEquals(sourceTiffOutputSet, duplicateTiffOutputSet);
+        assertTiffEquals(sourceTiffOutputSet, duplicateTiffOutputSet);
 
         /*
          * Copy the file to a duplicate file, using updateExifMetadataLossless and the duplicate TiffOutputSet
@@ -212,6 +213,6 @@ public class ExifRewriterRoundtripTest extends ExifBaseTest {
         /*
          * Compare the source TiffOutputSet to the one loaded from the duplicate file. This fails!
          */
-        assertEquals(sourceTiffOutputSet, duplicateTiffOutputSet);
+        assertTiffEquals(sourceTiffOutputSet, duplicateTiffOutputSet);
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/exif/TextFieldTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.imaging.formats.jpeg.exif;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -26,7 +28,6 @@ import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryType;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 
 public class TextFieldTest extends SpecificExifTagTest {
 
@@ -45,7 +46,7 @@ public class TextFieldTest extends SpecificExifTagTest {
 
         try {
             final Object textFieldValue = field.getValue();
-            Assertions.assertNotNull(textFieldValue);
+            assertNotNull(textFieldValue);
             // TODO what else to assert?
         } catch (final ImagingException e) {
             Debug.debug("imageFile", imageFile.getAbsoluteFile());

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcFullDiscardTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcFullDiscardTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.imaging.formats.jpeg.iptc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +26,6 @@ import java.util.Collections;
 
 import javax.imageio.ImageIO;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class IptcFullDiscardTest {
@@ -51,7 +52,7 @@ public class IptcFullDiscardTest {
         final byte[] originalImage = generateImage();
         final byte[] taggedImage = addMetaData(originalImage);
         final byte[] untaggedImage = removeMetaData(taggedImage, false);
-        Assertions.assertEquals(18, untaggedImage.length - originalImage.length);
+        assertEquals(18, untaggedImage.length - originalImage.length);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class IptcFullDiscardTest {
         final byte[] originalImage = generateImage();
         final byte[] taggedImage = addMetaData(originalImage);
         final byte[] untaggedImage = removeMetaData(taggedImage, true);
-        Assertions.assertEquals(originalImage.length, untaggedImage.length);
+        assertEquals(originalImage.length, untaggedImage.length);
     }
 
     private byte[] removeMetaData(final byte[] bytes, final boolean removeApp13Segment) throws Exception {

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/xmp/JpegXmpRewriteTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.imaging.formats.jpeg.xmp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -27,7 +28,6 @@ import java.util.stream.Stream;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 import org.apache.commons.imaging.formats.jpeg.JpegImagingParameters;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -59,7 +59,7 @@ public class JpegXmpRewriteTest extends JpegXmpBaseTest {
 
             final String outXmp = new JpegImageParser().getXmpXml(
                     ByteSource.array(noXmpFile, "test.jpg"), params);
-            Assertions.assertNull(outXmp);
+            assertNull(outXmp);
         }
 
         {

--- a/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pam/PamReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.pam;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -27,7 +28,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PamReadTest extends PamBaseTest {
@@ -42,7 +42,7 @@ public class PamReadTest extends PamBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/PcxReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.pcx;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -27,7 +28,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PcxReadTest extends PcxBaseTest {
@@ -42,7 +42,7 @@ public class PcxReadTest extends PcxBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngReadTest.java
@@ -18,6 +18,7 @@
 package org.apache.commons.imaging.formats.png;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -33,7 +34,6 @@ import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.GenericImageMetadata;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PngReadTest extends PngBaseTest {
@@ -54,19 +54,19 @@ public class PngReadTest extends PngBaseTest {
                 );
 
                 assertThrows(
-                        Exception.class,
-                        () -> Imaging.getImageInfo(imageFile),
-                        "Image read should have failed."
+                    Exception.class,
+                    () -> Imaging.getImageInfo(imageFile),
+                    "Image read should have failed."
                 );
 
                 assertThrows(
-                        Exception.class,
-                        () -> Imaging.getBufferedImage(imageFile),
-                        "Image read should have failed."
+                    Exception.class,
+                    () -> Imaging.getBufferedImage(imageFile),
+                    "Image read should have failed."
                 );
             } else {
                 final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-                Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+                assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
                 final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
                 assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWithInvalidPngChunkSizeTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.commons.imaging.formats.png;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.examples.ImageReadExample.ManagedImageBufferedImageFactory;
 import org.apache.commons.imaging.formats.jpeg.JpegWithInvalidDhtSegmentTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,7 +42,7 @@ public class PngWithInvalidPngChunkSizeTest {
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
+        assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
     }
 
     /**
@@ -54,6 +55,6 @@ public class PngWithInvalidPngChunkSizeTest {
         final PngImagingParameters params = new PngImagingParameters();
         params.setBufferedImageFactory(new ManagedImageBufferedImageFactory());
         final PngImageParser jpegImageParser = new PngImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
+        assertThrows(ImagingException.class, () -> jpegImageParser.getBufferedImage(imageFile, params));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccpTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.imaging.formats.png.chunks;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +30,6 @@ import java.util.zip.DeflaterOutputStream;
 
 import org.apache.commons.imaging.ImagingConstants;
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,7 +42,7 @@ public class PngChunkIccpTest {
     @Test
     public void testErrorOnNoProfileName() {
         final byte[] data = ImagingConstants.EMPTY_BYTE_ARRAY;
-        Assertions.assertThrows(ImagingException.class, () -> new PngChunkIccp(0, chunkType, 0, data));
+        assertThrows(ImagingException.class, () -> new PngChunkIccp(0, chunkType, 0, data));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkScalTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/chunks/PngChunkScalTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.imaging.formats.png.chunks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PngChunkScalTest {
@@ -28,27 +28,27 @@ public class PngChunkScalTest {
 
    @Test
    public void testConstruct_InvalidDblValue() {
-       Assertions.assertThrows(ImagingException.class,() -> new PngChunkScal(10, chunkType, 0, new byte[]{2, 65, 46, 48, 49, 0, 48, 46, 48, 50}));
+       assertThrows(ImagingException.class,() -> new PngChunkScal(10, chunkType, 0, new byte[]{2, 65, 46, 48, 49, 0, 48, 46, 48, 50}));
    }
 
    @Test
    public void testConstruct_InvalidUnitSpecifier() {
-       Assertions.assertThrows(ImagingException.class,() -> new PngChunkScal(10, chunkType, 0, new byte[]{3, 48, 46, 48, 49, 0, 48, 46, 48, 50}));
+       assertThrows(ImagingException.class,() -> new PngChunkScal(10, chunkType, 0, new byte[]{3, 48, 46, 48, 49, 0, 48, 46, 48, 50}));
    }
 
    @Test
    public void testConstruct_MissingSeparator() {
-      Assertions.assertThrows(ImagingException.class,() -> new PngChunkScal(9, chunkType, 0, new byte[]{1, 48, 46, 48, 49, 48, 46, 48, 50}));
+      assertThrows(ImagingException.class,() -> new PngChunkScal(9, chunkType, 0, new byte[]{1, 48, 46, 48, 49, 48, 46, 48, 50}));
    }
 
    @Test
    public void testConstruct_MissingXValue() {
-      Assertions.assertThrows(ImagingException.class,() -> new PngChunkScal(2, chunkType, 0, new byte[]{2, 0}));
+      assertThrows(ImagingException.class,() -> new PngChunkScal(2, chunkType, 0, new byte[]{2, 0}));
    }
 
    @Test
    public void testConstruct_MissingYValue() {
-       Assertions.assertThrows(ImagingException.class,() -> new PngChunkScal(6, chunkType, 0, new byte[]{2, 48, 46, 48, 49, 0}));
+       assertThrows(ImagingException.class,() -> new PngChunkScal(6, chunkType, 0, new byte[]{2, 48, 46, 48, 49, 0}));
    }
 
    @Test

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PgmFileInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PgmFileInfoTest.java
@@ -17,21 +17,21 @@
 package org.apache.commons.imaging.formats.pnm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PgmFileInfoTest {
 
     @Test
     public void testCreateThrowsImageReadExceptionOne() {
-        Assertions.assertThrows(ImagingException.class, () -> new PgmFileInfo(16711680, 16711680, false, 16711680));
+        assertThrows(ImagingException.class, () -> new PgmFileInfo(16711680, 16711680, false, 16711680));
     }
 
     @Test
     public void testCreateThrowsImageReadExceptionTwo() {
-        Assertions.assertThrows(ImagingException.class, () -> new PgmFileInfo(0, 0, true, 0));
+        assertThrows(ImagingException.class, () -> new PgmFileInfo(0, 0, true, 0));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PnmImageParserTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.imaging.formats.pnm;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
@@ -29,7 +30,6 @@ import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PnmImageParserTest {
@@ -53,7 +53,7 @@ public class PnmImageParserTest {
         final byte[] bytes = "P1\n2 a\n0 0\n0 0\n0 0\n0 0\n0 0\n0 1\n1 1\n1 1\n1 1\n1 1\n1 1\n".getBytes(US_ASCII);
         final PnmImagingParameters params = new PnmImagingParameters();
         final PnmImageParser underTest = new PnmImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
+        assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
     }
 
     /**
@@ -65,7 +65,7 @@ public class PnmImageParserTest {
         final byte[] bytes = "P1\na 2\n0 0 0 0 0 0 0 0 0 0 0\n1 1 1 1 1 1 1 1 1 1 1\n".getBytes(US_ASCII);
         final PnmImagingParameters params = new PnmImagingParameters();
         final PnmImageParser underTest = new PnmImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
+        assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class PnmImageParserTest {
         final byte[] bytes = "P7\nWIDTH \n".getBytes(US_ASCII);
         final PnmImagingParameters params = new PnmImagingParameters();
         final PnmImageParser underTest = new PnmImageParser();
-        Assertions.assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
+        assertThrows(ImagingException.class, () -> underTest.getImageInfo(bytes, params));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/imaging/formats/pnm/PpmFileInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pnm/PpmFileInfoTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.commons.imaging.formats.pnm;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,12 +30,12 @@ public class PpmFileInfoTest {
 
   @Test
   public void testCreatesPpmFileInfoOne() {
-      Assertions.assertThrows(ImagingException.class, () -> new PpmFileInfo(0, 0, false, 16711680));
+      assertThrows(ImagingException.class, () -> new PpmFileInfo(0, 0, false, 16711680));
   }
 
   @Test
   public void testCreatesPpmFileInfoThree() {
-      Assertions.assertThrows(ImagingException.class, () -> new PpmFileInfo(0, 0, true, 0));
+      assertThrows(ImagingException.class, () -> new PpmFileInfo(0, 0, true, 0));
   }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/psd/PsdReadTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.formats.psd;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -26,7 +27,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PsdReadTest extends PsdBaseTest {
@@ -41,7 +41,7 @@ public class PsdReadTest extends PsdBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/rgbe/RgbeReadTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.imaging.formats.rgbe;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -29,7 +30,6 @@ import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.bytesource.ByteSource;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RgbeReadTest extends RgbeBaseTest {
@@ -66,6 +66,6 @@ public class RgbeReadTest extends RgbeBaseTest {
                         .getFile());
         final ByteSource byteSourceFile = ByteSource.file(inputFile);
         final RgbeImagingParameters params = new RgbeImagingParameters();
-        Assertions.assertThrows(ImagingException.class, () -> new RgbeImageParser().getBufferedImage(byteSourceFile, params));
+        assertThrows(ImagingException.class, () -> new RgbeImageParser().getBufferedImage(byteSourceFile, params));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAsciiTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAsciiTest.java
@@ -17,12 +17,12 @@
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.formats.tiff.TiffField;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,7 +39,7 @@ public class FieldTypeAsciiTest {
       final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
       final TiffField tiffField = new TiffField(0, 0, fieldTypeAscii, 0L, 0, byteArray, byteOrder, 1);
 
-      Assertions.assertThrows(ImagingException.class, () -> fieldTypeAscii.writeData(tiffField, byteOrder));
+      assertThrows(ImagingException.class, () -> fieldTypeAscii.writeData(tiffField, byteOrder));
   }
 
   @Test

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeByteTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeByteTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FieldTypeByteTest{
@@ -29,7 +30,7 @@ public class FieldTypeByteTest{
       final FieldTypeByte fieldTypeByte = FieldType.UNDEFINED;
       final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
 
-      Assertions.assertThrows(ImagingException.class, () -> fieldTypeByte.writeData( null, byteOrder));
+      assertThrows(ImagingException.class, () -> fieldTypeByte.writeData( null, byteOrder));
   }
 
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRationalTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRationalTest.java
@@ -17,11 +17,11 @@
 package org.apache.commons.imaging.formats.tiff.fieldtypes;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteOrder;
 
 import org.apache.commons.imaging.ImagingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,7 +35,7 @@ public class FieldTypeRationalTest {
   public void testWriteDataWithNonNull() {
       final FieldTypeRational fieldTypeRational = new FieldTypeRational((-922), "z_AX");
       final ByteOrder byteOrder = ByteOrder.nativeOrder();
-      Assertions.assertThrows(ImagingException.class, () -> fieldTypeRational.writeData("z_AX", byteOrder));
+      assertThrows(ImagingException.class, () -> fieldTypeRational.writeData("z_AX", byteOrder));
   }
 
   @Test

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/photometricinterpreters/PhotometricInterpreterLogLuvTest.java
@@ -17,13 +17,13 @@
 package org.apache.commons.imaging.formats.tiff.photometricinterpreters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.common.ImageBuilder;
 import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterLogLuv.TristimulusValues;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -99,11 +99,11 @@ public class PhotometricInterpreterLogLuvTest {
 
     @Test
     public void testInterpretPixelEmptySamples() {
-        Assertions.assertThrows(ImagingException.class, () -> p.interpretPixel(null, new int[] {}, 0, 0));
+        assertThrows(ImagingException.class, () -> p.interpretPixel(null, new int[] {}, 0, 0));
     }
 
     @Test
     public void testInterpretPixelNullSamples() {
-        Assertions.assertThrows(ImagingException.class, () -> p.interpretPixel(null, null, 0, 0));
+        assertThrows(ImagingException.class, () -> p.interpretPixel(null, null, 0, 0));
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/wbmp/WbmpReadTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.commons.imaging.formats.wbmp;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -24,7 +25,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class WbmpReadTest extends WbmpBaseTest {
@@ -39,7 +39,7 @@ public class WbmpReadTest extends WbmpBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xbm/XbmReadTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.commons.imaging.formats.xbm;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -24,7 +25,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class XbmReadTest extends XbmBaseTest {
@@ -39,7 +39,7 @@ public class XbmReadTest extends XbmBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/xpm/XpmReadTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.commons.imaging.formats.xpm;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -24,7 +25,6 @@ import org.apache.commons.imaging.ImageInfo;
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.internal.Debug;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class XpmReadTest extends XpmBaseTest {
@@ -39,7 +39,7 @@ public class XpmReadTest extends XpmBaseTest {
             Debug.debug("imageFile", imageFile);
 
             final ImageMetadata metadata = Imaging.getMetadata(imageFile);
-            Assertions.assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
+            assertFalse(metadata instanceof File); // Dummy check to avoid unused warning (it may be null)
 
             final ImageInfo imageInfo = Imaging.getImageInfo(imageFile);
             assertNotNull(imageInfo);

--- a/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/ImageAsserts.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.roundtrip;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
@@ -25,17 +26,16 @@ import java.io.IOException;
 
 import org.apache.commons.imaging.internal.Debug;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 
 final class ImageAsserts {
 
-    static void assertEquals(final BufferedImage a, final BufferedImage b) {
-        assertEquals(a, b, 0);
+    static void assertImageEquals(final BufferedImage a, final BufferedImage b) {
+        assertImageEquals(a, b, 0);
     }
 
-    static void assertEquals(final BufferedImage a, final BufferedImage b, final int tolerance) {
-        Assertions.assertEquals(a.getWidth(), b.getWidth());
-        Assertions.assertEquals(a.getHeight(), b.getHeight());
+    static void assertImageEquals(final BufferedImage a, final BufferedImage b, final int tolerance) {
+        assertEquals(a.getWidth(), b.getWidth());
+        assertEquals(a.getHeight(), b.getHeight());
 
         for (int x = 0; x < a.getWidth(); x++) {
             for (int y = 0; y < a.getHeight(); y++) {
@@ -55,15 +55,15 @@ final class ImageAsserts {
                     Debug.debug("aArgb: " + aArgb + " (0x" + Integer.toHexString(aArgb) + ")");
                     Debug.debug("bArgb: " + bArgb + " (0x" + Integer.toHexString(bArgb) + ")");
                 }
-                Assertions.assertEquals(aArgb, bArgb);
+                assertEquals(aArgb, bArgb);
             }
         }
     }
 
-    static void assertEquals(final File a, final File b) throws IOException {
+    static void assertFileEquals(final File a, final File b) throws IOException {
         assertTrue(a.exists() && a.isFile());
         assertTrue(b.exists() && b.isFile());
-        Assertions.assertEquals(a.length(), b.length());
+        assertEquals(a.length(), b.length());
 
         final byte[] aData = FileUtils.readFileToByteArray(a);
         final byte[] bData = FileUtils.readFileToByteArray(b);
@@ -79,7 +79,7 @@ final class ImageAsserts {
                 Debug.debug("aByte: " + aByte + " (0x" + Integer.toHexString(aByte) + ")");
                 Debug.debug("bByte: " + bByte + " (0x" + Integer.toHexString(bByte) + ")");
             }
-            Assertions.assertEquals(aByte, bByte);
+            assertEquals(aByte, bByte);
         }
     }
 

--- a/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
+++ b/src/test/java/org/apache/commons/imaging/roundtrip/RoundtripBase.java
@@ -58,7 +58,7 @@ public class RoundtripBase {
         if (imageExact) {
             // note tolerance when comparing grayscale images
             // BufferedImages of
-            ImageAsserts.assertEquals(testImage, image2);
+            ImageAsserts.assertImageEquals(testImage, image2);
         }
 
         if (formatInfo.identicalSecondWrite) {


### PR DESCRIPTION
Currently `static` imports aren't used consistently for JUnit's `org.junit.jupiter.api.Assertions` methods.