### PR TITLE
Issue-360: Add more TIFF compression entries to ImageInfo

### DIFF
--- a/src/main/java/org/apache/commons/imaging/ImageInfo.java
+++ b/src/main/java/org/apache/commons/imaging/ImageInfo.java
@@ -57,6 +57,7 @@ public class ImageInfo {
         NONE("None"),
         LZW("LZW"),
         PACKBITS("PackBits"),
+        JPEG_TIFF_OBSOLETE("JPEG Obsolete (TIFF only)"),
         JPEG("JPEG"),
         RLE("RLE: Run-Length Encoding"),
         ADAPTIVE_RLE("Adaptive RLE"),
@@ -64,7 +65,8 @@ public class ImageInfo {
         PNG_FILTER("PNG Filter"),
         CCITT_GROUP_3("CCITT Group 3 1-Dimensional Modified Huffman run-length encoding."),
         CCITT_GROUP_4("CCITT Group 4"),
-        CCITT_1D("CCITT 1D");
+        CCITT_1D("CCITT 1D"),
+        DEFLATE("DEFLATE (ZIP)");
 
         private final String description;
 

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -49,6 +49,9 @@ import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.common.XmpEmbeddable;
 import org.apache.commons.imaging.common.XmpImagingParameters;
 import org.apache.commons.imaging.formats.tiff.TiffDirectory.ImageDataElement;
+import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.TIFF_COMPRESSION_DEFLATE_ADOBE;
+import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.TIFF_COMPRESSION_DEFLATE_PKZIP;
+import static org.apache.commons.imaging.formats.tiff.constants.TiffConstants.TIFF_COMPRESSION_JPEG_OBSOLETE;
 import org.apache.commons.imaging.formats.tiff.constants.TiffEpTagConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffPlanarConfiguration;
 import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
@@ -558,6 +561,9 @@ public class TiffImageParser extends ImageParser<TiffImagingParameters> implemen
         case TIFF_COMPRESSION_LZW:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.LZW;
             break;
+        case TIFF_COMPRESSION_JPEG_OBSOLETE:
+            compressionAlgorithm = ImageInfo.CompressionAlgorithm.JPEG_TIFF_OBSOLETE;
+            break;
         case TIFF_COMPRESSION_JPEG:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.JPEG;
             break;
@@ -567,6 +573,10 @@ public class TiffImageParser extends ImageParser<TiffImagingParameters> implemen
         case TIFF_COMPRESSION_PACKBITS:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.PACKBITS;
             break;
+       case TIFF_COMPRESSION_DEFLATE_PKZIP:
+       case TIFF_COMPRESSION_DEFLATE_ADOBE:
+          compressionAlgorithm = ImageInfo.CompressionAlgorithm.DEFLATE;
+          break;
         default:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.UNKNOWN;
             break;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/constants/TiffConstants.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/constants/TiffConstants.java
@@ -38,7 +38,8 @@ public final class TiffConstants {
     public static final int TIFF_COMPRESSION_CCITT_GROUP_3 = 3;
     public static final int TIFF_COMPRESSION_CCITT_GROUP_4 = 4;
     public static final int TIFF_COMPRESSION_LZW = 5;
-    public static final int TIFF_COMPRESSION_JPEG = 6;
+    public static final int TIFF_COMPRESSION_JPEG_OBSOLETE = 6;
+    public static final int TIFF_COMPRESSION_JPEG = 7;
     public static final int TIFF_COMPRESSION_UNCOMPRESSED_2 = 32771;
     public static final int TIFF_COMPRESSION_PACKBITS = 32773;
     public static final int TIFF_COMPRESSION_DEFLATE_PKZIP = 32946;


### PR DESCRIPTION
This pull request adds more information about TIFF data compression variations to the ImageInfo available for TIFF files.

**Detail from Issue-360**

The ImageInfo for TIFF is missing information related to three TIFF compression options, two of which are quite commonly used. I propose to modify the TiffImageParser class to populate these values.
 
```
TIFF_COMPRESSION_DEFLATE_PKZIP 
TIFF_COMPRESSION_DEFLATE_ADOBE 
```

Additionally, the TIFF format has an obsolete variation on JPEG that was abandoned in the 1990's.  Commons Imaging does not currently support TIFF JPEG compression, though many of the pieces needed are already in its code base.  I propose to do the following:

The current code has a class called TiffConstants that includes the definition for
 
`    TIFF_COMPRESSION_JPEG = 6; `

Code 6 is the obsolete JPEG variation.  Code 7 is the format currently used in many TIFF utilities. So I propose to modify the constants and as follows
 
```
TIFF_COMPRESSION_JPEG_OBSOLETE = 6
TIFF_COMPRESSION_JPEG = 7
```
 
 