### PR TITLE
[IMAGING-337] Make ImageInfo state correct color type

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -66,6 +66,12 @@ import org.apache.commons.imaging.formats.tiff.photometricinterpreters.Photometr
 import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterYCbCr;
 import org.apache.commons.imaging.formats.tiff.write.TiffImageWriterLossy;
 
+/**
+ * Implements methods for reading and writing TIFF files. Instances of this
+ * class are invoked from the general Imaging class. Applications that
+ * require the use of TIFF-specific features may instantiate and access
+ * this class directly.
+ */
 public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> implements XmpEmbeddable<TiffImagingParameters> {
 
     private static final String DEFAULT_EXTENSION = ImageFormats.TIFF.getDefaultExtension();
@@ -537,9 +543,9 @@ public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> 
         final int photoInterp = 0xffff & directory.getFieldValue(TiffTagConstants.TIFF_TAG_PHOTOMETRIC_INTERPRETATION);
         final TiffField extraSamplesField = directory.findField(TiffTagConstants.TIFF_TAG_EXTRA_SAMPLES);
         final int extraSamples;
-        if(extraSamplesField == null){
+        if (extraSamplesField == null) {
             extraSamples = 0; // no extra samples value
-        }else{
+        } else {
             extraSamples = extraSamplesField.getIntValue();
         }
         final TiffField samplesPerPixelField = directory.findField(TiffTagConstants.TIFF_TAG_SAMPLES_PER_PIXEL);

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -527,14 +527,57 @@ public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> 
 
         final String formatDetails = "TIFF v." + contents.header.tiffVersion;
 
-        final boolean transparent = false; // TODO: wrong
+        boolean transparent = false; // TODO: wrong
         boolean usesPalette = false;
         final TiffField colorMapField = directory.findField(TiffTagConstants.TIFF_TAG_COLOR_MAP);
         if (colorMapField != null) {
             usesPalette = true;
         }
 
-        final ImageInfo.ColorType colorType = ImageInfo.ColorType.RGB;
+        final int photoInterp = 0xffff & directory.getFieldValue(TiffTagConstants.TIFF_TAG_PHOTOMETRIC_INTERPRETATION);
+        final TiffField extraSamplesField = directory.findField(TiffTagConstants.TIFF_TAG_EXTRA_SAMPLES);
+        final int extraSamples;
+        if(extraSamplesField == null){
+            extraSamples = 0; // no extra samples value
+        }else{
+            extraSamples = extraSamplesField.getIntValue();
+        }
+        final TiffField samplesPerPixelField = directory.findField(TiffTagConstants.TIFF_TAG_SAMPLES_PER_PIXEL);
+        final int samplesPerPixel;
+        if (samplesPerPixelField == null) {
+            samplesPerPixel = 1;
+        } else {
+            samplesPerPixel = samplesPerPixelField.getIntValue();
+        }
+
+        final ImageInfo.ColorType colorType;
+        switch (photoInterp) {
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_BLACK_IS_ZERO:
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_WHITE_IS_ZERO:
+                // the ImageInfo.ColorType enumeration does not distinguish
+                // between monotone white is zero or black is zero
+                colorType = ImageInfo.ColorType.BW;
+                break;
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_RGB:
+                colorType = ImageInfo.ColorType.RGB;
+                // even if 4 samples per pixel are included, TIFF
+                // doesn't specify transparent unless the optional "extra samples"
+                // field is supplied with a non-zero value
+                transparent = samplesPerPixel == 4 && extraSamples != 0;
+                break;
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_RGB_PALETTE:
+                colorType = ImageInfo.ColorType.RGB;
+                usesPalette = true;
+                break;
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_CMYK:
+                colorType = ImageInfo.ColorType.CMYK;
+                break;
+            case TiffTagConstants.PHOTOMETRIC_INTERPRETATION_VALUE_YCB_CR:
+                colorType = ImageInfo.ColorType.YCbCr;
+                break;
+            default:
+                colorType = ImageInfo.ColorType.UNKNOWN;
+        }
 
         final short compressionFieldValue;
         if (directory.findField(TiffTagConstants.TIFF_TAG_COMPRESSION) != null) {
@@ -573,10 +616,10 @@ public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> 
         case TIFF_COMPRESSION_PACKBITS:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.PACKBITS;
             break;
-       case TIFF_COMPRESSION_DEFLATE_PKZIP:
-       case TIFF_COMPRESSION_DEFLATE_ADOBE:
-          compressionAlgorithm = ImageInfo.CompressionAlgorithm.DEFLATE;
-          break;
+        case TIFF_COMPRESSION_DEFLATE_PKZIP:
+        case TIFF_COMPRESSION_DEFLATE_ADOBE:
+            compressionAlgorithm = ImageInfo.CompressionAlgorithm.DEFLATE;
+            break;
         default:
             compressionAlgorithm = ImageInfo.CompressionAlgorithm.UNKNOWN;
             break;

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
@@ -41,7 +41,6 @@ public class TiffReadImageInfoTest extends TiffBaseTest {
         {"10/Imaging247.tiff", "Uses Palette", "true"},
         {"12/TransparencyTestStripAssociated.tif", "Is Transparent", "true"},
         {"14/TestJpegStrips.tiff", "Color Type", "YCbCr"}
-
     };
 
     /**
@@ -54,7 +53,7 @@ public class TiffReadImageInfoTest extends TiffBaseTest {
      * @return the value
      */
     private String getValue(ImageInfo info, String target) {
-        String s = info.toString();
+        final String s = info.toString();
         int i = s.indexOf(target);
         if (i < 0) {
             return "";
@@ -67,8 +66,7 @@ public class TiffReadImageInfoTest extends TiffBaseTest {
         if (k < j) {
             return "";
         }
-        String q = s.substring(j + 1, k).trim();
-        return q;
+        return s.substring(j + 1, k).trim();
     }
 
     private File getTiffFile(String name) {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
@@ -77,10 +77,10 @@ public class TiffReadImageInfoTest extends TiffBaseTest {
     @Test
     public void testImageInfoElements() throws Exception {
         for (String[] testTarget : testSet) {
-            File targetFile = getTiffFile(testTarget[0]);
-            ImageInfo info = Imaging.getImageInfo(targetFile);
-            String value = getValue(info, testTarget[1]);
-            String identifier = targetFile.getName() + ": " + testTarget[1];
+            final File targetFile = getTiffFile(testTarget[0]);
+            final ImageInfo info = Imaging.getImageInfo(targetFile);
+            final String value = getValue(info, testTarget[1]);
+            final String identifier = targetFile.getName() + ": " + testTarget[1];
             assertEquals(value.toLowerCase(), testTarget[2].toLowerCase(), identifier);
         }
     }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadImageInfoTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.formats.tiff;
+
+import java.io.File;
+import org.apache.commons.imaging.ImageInfo;
+import org.apache.commons.imaging.Imaging;
+import org.apache.commons.imaging.ImagingTestConstants;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Performs a test on the ImageInfo returned from TIFF to confirm
+ * that it contains the specified value for a particular target.
+ * This test is used to confirm that the TiffImageParser is correctly
+ * interpreting the ImageInfo values.
+ */
+public class TiffReadImageInfoTest extends TiffBaseTest {
+
+    // The form of the test set is
+    //    0.   target file name
+    //    1.   Parameter field in ImageInfo
+    //    2.   Expected value
+    static final String[][] testSet = {
+        {"1/matthew2.tif", "Color Type", "Black and White"},
+        {"7/Oregon Scientific DS6639 - DSC_0307 - small - CMYK.tiff", "Color Type", "CMYK"},
+        {"10/Imaging247.tiff", "Uses Palette", "true"},
+        {"12/TransparencyTestStripAssociated.tif", "Is Transparent", "true"},
+        {"14/TestJpegStrips.tiff", "Color Type", "YCbCr"}
+
+    };
+
+    /**
+     * Gets the value for the target data field within the ImageInfo string.
+     * This method expects data fields to be given in the form:
+     * parameter name, colon, value, end-of-line
+     *
+     * @param info a valid instance obtained from TiffImageParser
+     * @param target the target data field string
+     * @return the value
+     */
+    private String getValue(ImageInfo info, String target) {
+        String s = info.toString();
+        int i = s.indexOf(target);
+        if (i < 0) {
+            return "";
+        }
+        int j = s.indexOf(':', i);
+        if (j < 0) {
+            return "";
+        }
+        int k = s.indexOf('\n', j);
+        if (k < j) {
+            return "";
+        }
+        String q = s.substring(j + 1, k).trim();
+        return q;
+    }
+
+    private File getTiffFile(String name) {
+        final File tiffFolder = new File(ImagingTestConstants.TEST_IMAGE_FOLDER, "tiff");
+        return new File(tiffFolder, name);
+    }
+
+    @Test
+    public void testImageInfoElements() throws Exception {
+        for (String[] testTarget : testSet) {
+            File targetFile = getTiffFile(testTarget[0]);
+            ImageInfo info = Imaging.getImageInfo(targetFile);
+            String value = getValue(info, testTarget[1]);
+            String identifier = targetFile.getName() + ": " + testTarget[1];
+            assertEquals(value.toLowerCase(), testTarget[2].toLowerCase(), identifier);
+        }
+    }
+
+}


### PR DESCRIPTION
This change addresses issues 337 and 361.  361 is redundant with 337.  The ImageInfo for TIFF was giving the wrong ColorType value for some TIFF files (it was hardwired to RGB).

I also made one unrelated cosmetic change on lines 619-626 where I fixed the indentation to match the Commons Imaging standard.

A new JUnit test for TIFF files was introduced to verify that expected values are obtained from ImageInfo, see TiffReadImageInfoTest.java