### PR TITLE
Avoid NullPointerException in TiffImageParser.getBufferedImage()

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -340,7 +340,7 @@ public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> 
             }
         }
 
-        PhotometricInterpreter photometricInterpreter = params.getCustomPhotometricInterpreter();
+        PhotometricInterpreter photometricInterpreter = params == null ? null : params.getCustomPhotometricInterpreter();
         if (photometricInterpreter == null) {
             photometricInterpreter = getPhotometricInterpreter(directory, photometricInterpretation, bitsPerPixel, bitsPerSample, predictor, samplesPerPixel,
                     width, height);

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
@@ -76,19 +76,14 @@ public class TiffReadTest extends TiffBaseTest {
     @Test
     public void testReadAllImages() throws Exception {
         // same as above, but test read all Images
-        List<File> tiffImages = getTiffImages();
-        for (final File imageFile : tiffImages) {
-
-            final String name = imageFile.getName();
+        for (final File imageFile : getTiffImages()) {
             // the "bad offsets" file will cause an exception to be thrown.
             // It's not relevant to what this test is trying to discover.
             // So skip it.
-            if (name.toLowerCase().contains("bad")) {
+            if (imageFile.getName().toLowerCase().contains("bad")) {
                 continue;
             }
-
-            List<BufferedImage> allBufferedImages = Imaging.getAllBufferedImages(imageFile);
-            assertFalse(allBufferedImages.isEmpty());
+            assertFalse(Imaging.getAllBufferedImages(imageFile).isEmpty());
         }
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/TiffReadTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.imaging.formats.tiff;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
@@ -69,6 +70,25 @@ public class TiffReadTest extends TiffBaseTest {
             final TiffReader tiffReader = new TiffReader(true);
             final TiffContents contents = tiffReader.readDirectories(byteSource, true, FormatCompliance.getDefault());
             assertNotNull(contents);
+        }
+    }
+
+    @Test
+    public void testReadAllImages() throws Exception {
+        // same as above, but test read all Images
+        List<File> tiffImages = getTiffImages();
+        for (final File imageFile : tiffImages) {
+
+            final String name = imageFile.getName();
+            // the "bad offsets" file will cause an exception to be thrown.
+            // It's not relevant to what this test is trying to discover.
+            // So skip it.
+            if (name.toLowerCase().contains("bad")) {
+                continue;
+            }
+
+            List<BufferedImage> allBufferedImages = Imaging.getAllBufferedImages(imageFile);
+            assertFalse(allBufferedImages.isEmpty());
         }
     }
 }


### PR DESCRIPTION
Avoid NullPointerException in TiffImageParser.getBufferedImage(TiffDirectory，ByteOrder,TiffImagingParameters) when TiffImagingParameters is null