### PR TITLE
[IMAGING-351] ExifRewriterRoundtripTest fixed, completed & enabled

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,9 @@ The <action> type attribute can be add,update,fix,remove.
       <!-- UPDATE -->
       <action dev="ggregory" type="update" due-to="Dependabot">Bump org.apache.commons:commons-parent from 67 to 69 #382.</action>
       <action dev="ggregory" type="update" due-to="Dependabot">Bump commons-io:commons-io from 2.16.0 to 2.16.1 #385.</action>
+      <action issue="IMAGING-351" dev="kinow" type="update" due-to="Stefan Oltmann, Gary Lucas">
+        Fix ExifRewriterRoundtripTest that was disabled.
+      </action>
     </release>
     <release version="1.0.0-alpha4" date="2024-03-30" description="The 1.0.0-alpha4 release requires Java 8.">
       <!-- FIX -->

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossless.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffImageWriterLossless.java
@@ -45,6 +45,9 @@ import org.apache.commons.imaging.formats.tiff.TiffImagingParameters;
 import org.apache.commons.imaging.formats.tiff.TiffReader;
 import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
 
+/**
+ * TIFF lossless image writer.
+ */
 public class TiffImageWriterLossless extends AbstractTiffImageWriter {
     private static final class BufferOutputStream extends OutputStream {
         private final byte[] buffer;
@@ -104,7 +107,7 @@ public class TiffImageWriterLossless extends AbstractTiffImageWriter {
                     final AbstractTiffElement oversizeValue = field.getOversizeValueElement();
                     if (oversizeValue != null) {
                         final TiffOutputField frozenField = frozenFields.get(field.getTag());
-                        if (frozenField != null && frozenField.getSeperateValue() != null && frozenField.bytesEqual(field.getByteArrayValue())) {
+                        if (frozenField != null && frozenField.getSeperateValue() != null && Arrays.equals(frozenField.getData(), field.getByteArrayValue())) {
                             frozenField.getSeperateValue().setOffset(field.getOffset());
                         } else {
                             elements.add(oversizeValue);

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputField.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputField.java
@@ -62,10 +62,6 @@ public class TiffOutputField {
         this(tagInfo.tag, tagInfo, abstractFieldType, count, bytes);
     }
 
-    public boolean bytesEqual(final byte[] data) {
-        return Arrays.equals(bytes, data);
-    }
-
     protected AbstractTiffOutputItem getSeperateValue() {
         return separateValueItem;
     }
@@ -78,7 +74,13 @@ public class TiffOutputField {
         return bytes.length <= TIFF_ENTRY_MAX_VALUE_LENGTH;
     }
 
-    protected void setData(final byte[] bytes) throws ImagingException {
+    /**
+     * Set the data for this TIFF output field.
+     *
+     * @param bytes TIFF output field data.
+     * @throws ImagingException if the length of the bytes array do not match.
+     */
+    public void setData(final byte[] bytes) throws ImagingException {
         // if (tagInfo.isUnknown())
         // Debug.debug("unknown tag(0x" + Integer.toHexString(tag)
         // + ") setData", bytes);
@@ -95,6 +97,14 @@ public class TiffOutputField {
         // if (isLocalValue() != wasLocalValue)
         // throw new Error("Bug. Locality disrupted! "
         // + tagInfo.getDescription());
+    }
+
+    /**
+     * Return a copy of the data in this TIFF output field.
+     * @return a copy of the data in this TIFF output field.
+     */
+    public byte[] getData() {
+        return Arrays.copyOf(this.bytes, this.bytes.length);
     }
 
     public void setSortHint(final int sortHint) {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectoryTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectoryTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.imaging.formats.tiff.write;
 
 import static org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants.TIFF_TAG_DOCUMENT_NAME;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants;
 import org.apache.commons.imaging.formats.tiff.constants.TiffDirectoryConstants;
@@ -44,6 +44,6 @@ public class TiffOutputDirectoryTest {
         assertNotNull(field);
         assertEquals(TIFF_TAG_DOCUMENT_NAME, field.tagInfo);
         final byte[] documentNameAsBytes = TIFF_TAG_DOCUMENT_NAME.encodeValue(TiffConstants.DEFAULT_TIFF_BYTE_ORDER, "Test.tiff");
-        assertTrue(field.bytesEqual(documentNameAsBytes));
+        assertArrayEquals(field.getData(), documentNameAsBytes);
     }
 }

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSetTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputSetTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.imaging.formats.tiff.write;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,7 +45,7 @@ public class TiffOutputSetTest {
         final TiffOutputField gpsVersionId = tiffOutputSet.findField(GpsTagConstants.GPS_TAG_GPS_VERSION_ID);
 
         assertNotNull(gpsVersionId);
-        assertTrue(gpsVersionId.bytesEqual(GpsTagConstants.gpsVersion()));
+        assertArrayEquals(gpsVersionId.getData(), GpsTagConstants.gpsVersion());
     }
 
 }


### PR DESCRIPTION
This completes the work started in PR #275.

This unit test will prove that the fix in PR #359 / #203 is correct.

Drop this [testfile.jpg](https://github.com/apache/commons-imaging/assets/9299303/2826b4ee-473a-45fb-b9fc-2168b9ae3fca) into `src/test/resources/data/images/jpg` to make the test fail.