### PR TITLE
Improve memory allocation and validation

### DIFF
--- a/src/main/java/org/apache/commons/imaging/bytesource/InputStreamByteSource.java
+++ b/src/main/java/org/apache/commons/imaging/bytesource/InputStreamByteSource.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.commons.imaging.ImagingException;
-import org.apache.commons.imaging.common.Allocator;
 import org.apache.commons.imaging.common.BinaryFunctions;
+import org.apache.commons.imaging.common.KnownSizeByteArrayBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.build.AbstractOrigin.InputStreamOrigin;
 
@@ -191,18 +191,9 @@ final class InputStreamByteSource extends ByteSource {
         final InputStream cis = getInputStream();
         BinaryFunctions.skipBytes(cis, position);
 
-        final byte[] bytes = Allocator.byteArray(length);
-        int total = 0;
-        while (true) {
-            final int read = cis.read(bytes, total, bytes.length - total);
-            if (read < 1) {
-                throw new ImagingException("Could not read block.");
-            }
-            total += read;
-            if (total >= length) {
-                return bytes;
-            }
-        }
+        KnownSizeByteArrayBuilder byteArrayBuilder = new KnownSizeByteArrayBuilder(length);
+        byteArrayBuilder.addAllBytesFrom(cis);
+        return byteArrayBuilder.createByteArray();
     }
 
     private Block getFirstBlock() throws IOException {

--- a/src/main/java/org/apache/commons/imaging/common/BasicCParser.java
+++ b/src/main/java/org/apache/commons/imaging/common/BasicCParser.java
@@ -353,7 +353,8 @@ public class BasicCParser {
                 ++numLiveTokens;
             }
         }
-        final String[] liveTokens = Allocator.array(numLiveTokens, String[]::new, 24);
+        // Trusted because length is based on length of existing array
+        final String[] liveTokens = Allocator.arrayTrusted(numLiveTokens, String[]::new, 24);
         int next = 0;
         for (final String token : tokens) {
             if (token != null && !token.isEmpty()) {

--- a/src/main/java/org/apache/commons/imaging/common/ByteConversions.java
+++ b/src/main/java/org/apache/commons/imaging/common/ByteConversions.java
@@ -57,11 +57,21 @@ public final class ByteConversions {
         return toBytes(values, 0, values.length, byteOrder);
     }
 
+    // TODO Replace this with java.util.Objects.checkFromIndexSize(int, int, int) once targeting Java 9+
+    private static void checkOffsetAndLength(int arrayLength, int offset, int length) {
+        if (offset < 0 || length < 0 || arrayLength - length < offset) {
+            throw new IllegalArgumentException("Invalid offset or length");
+        }
+    }
+
     private static byte[] toBytes(final double[] values, final int offset,
             final int length, final ByteOrder byteOrder) {
-        final byte[] result = Allocator.byteArray(length * 8);
+        checkOffsetAndLength(values.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final byte[] result = Allocator.byteArrayTrusted(length * Double.BYTES);
         for (int i = 0; i < length; i++) {
-            toBytes(values[offset + i], byteOrder, result, i * 8);
+            toBytes(values[offset + i], byteOrder, result, i * Double.BYTES);
         }
         return result;
     }
@@ -92,9 +102,12 @@ public final class ByteConversions {
     }
 
     private static byte[] toBytes(final float[] values, final int offset, final int length, final ByteOrder byteOrder) {
-        final byte[] result = Allocator.byteArray(length * 4);
+        checkOffsetAndLength(values.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final byte[] result = Allocator.byteArrayTrusted(length * Float.BYTES);
         for (int i = 0; i < length; i++) {
-            toBytes(values[offset + i], byteOrder, result, i * 4);
+            toBytes(values[offset + i], byteOrder, result, i * Float.BYTES);
         }
         return result;
     }
@@ -124,9 +137,12 @@ public final class ByteConversions {
     }
 
     private static byte[] toBytes(final int[] values, final int offset, final int length, final ByteOrder byteOrder) {
-        final byte[] result = Allocator.byteArray(length * 4);
+        checkOffsetAndLength(values.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final byte[] result = Allocator.byteArrayTrusted(length * Integer.BYTES);
         for (int i = 0; i < length; i++) {
-            toBytes(values[offset + i], byteOrder, result, i * 4);
+            toBytes(values[offset + i], byteOrder, result, i * Integer.BYTES);
         }
         return result;
     }
@@ -166,7 +182,10 @@ public final class ByteConversions {
 
     private static byte[] toBytes(final RationalNumber[] values, final int offset,
             final int length, final ByteOrder byteOrder) {
-        final byte[] result = Allocator.byteArray(length * 8);
+        checkOffsetAndLength(values.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final byte[] result = Allocator.byteArrayTrusted(length * 8);
         for (int i = 0; i < length; i++) {
             toBytes(values[offset + i], byteOrder, result, i * 8);
         }
@@ -194,9 +213,12 @@ public final class ByteConversions {
     }
 
     private static byte[] toBytes(final short[] values, final int offset, final int length, final ByteOrder byteOrder) {
-        final byte[] result = Allocator.byteArray(length * 2);
+        checkOffsetAndLength(values.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final byte[] result = Allocator.byteArrayTrusted(length * Short.BYTES);
         for (int i = 0; i < length; i++) {
-            toBytes(values[offset + i], byteOrder, result, i * 2);
+            toBytes(values[offset + i], byteOrder, result, i * Short.BYTES);
         }
         return result;
     }
@@ -233,8 +255,11 @@ public final class ByteConversions {
 
     private static double[] toDoubles(final byte[] bytes, final int offset,
             final int length, final ByteOrder byteOrder) {
-        final double[] result = Allocator.doubleArray(length / 8);
-        Arrays.setAll(result, i -> toDouble(bytes, offset + 8 * i, byteOrder));
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final double[] result = Allocator.doubleArrayTrusted(length / Double.BYTES);
+        Arrays.setAll(result, i -> toDouble(bytes, offset + Double.BYTES * i, byteOrder));
         return result;
     }
 
@@ -262,9 +287,12 @@ public final class ByteConversions {
 
     private static float[] toFloats(final byte[] bytes, final int offset,
             final int length, final ByteOrder byteOrder) {
-        final float[] result = Allocator.floatArray(length / 4);
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final float[] result = Allocator.floatArrayTrusted(length / Float.BYTES);
         for (int i = 0; i < result.length; i++) {
-            result[i] = toFloat(bytes, offset + 4 * i, byteOrder);
+            result[i] = toFloat(bytes, offset + Float.BYTES * i, byteOrder);
         }
         return result;
     }
@@ -290,8 +318,11 @@ public final class ByteConversions {
 
     private static int[] toInts(final byte[] bytes, final int offset, final int length,
             final ByteOrder byteOrder) {
-        final int[] result = Allocator.intArray(length / 4);
-        Arrays.setAll(result, i -> toInt(bytes, offset + 4 * i, byteOrder));
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final int[] result = Allocator.intArrayTrusted(length / Integer.BYTES);
+        Arrays.setAll(result, i -> toInt(bytes, offset + Integer.BYTES * i, byteOrder));
         return result;
     }
 
@@ -349,7 +380,10 @@ public final class ByteConversions {
             final int length,
             final ByteOrder byteOrder,
             final boolean unsignedType) {
-        final RationalNumber[] result = new RationalNumber[length / 8];
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final RationalNumber[] result = Allocator.arrayTrusted(length / 8, RationalNumber[]::new, 1);
         Arrays.setAll(result, i -> toRational(bytes, offset + 8 * i, byteOrder, unsignedType));
         return result;
     }
@@ -368,9 +402,12 @@ public final class ByteConversions {
 
     private static short[] toShorts(final byte[] bytes, final int offset,
             final int length, final ByteOrder byteOrder) {
-        final short[] result = Allocator.shortArray(length / 2);
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final short[] result = Allocator.shortArrayTrusted(length / Short.BYTES);
         for (int i = 0; i < result.length; i++) {
-            result[i] = toShort(bytes, offset + 2 * i, byteOrder);
+            result[i] = toShort(bytes, offset + Short.BYTES * i, byteOrder);
         }
         return result;
     }
@@ -394,7 +431,10 @@ public final class ByteConversions {
 
     private static int[] toUInt16s(final byte[] bytes, final int offset, final int length,
             final ByteOrder byteOrder) {
-        final int[] result = Allocator.intArray(length / 2);
+        checkOffsetAndLength(bytes.length, offset, length);
+
+        // Trusted because length is based on length of existing array
+        final int[] result = Allocator.intArrayTrusted(length / 2);
         Arrays.setAll(result, i -> toUInt16(bytes, offset + 2 * i, byteOrder));
         return result;
     }

--- a/src/main/java/org/apache/commons/imaging/common/ImageBuilder.java
+++ b/src/main/java/org/apache/commons/imaging/common/ImageBuilder.java
@@ -127,14 +127,14 @@ public class ImageBuilder {
         if (x < 0 || x >= width) {
             throw new RasterFormatException("subimage x is outside raster");
         }
-        if (x + w > width) {
+        if (width - w < x) {
             throw new RasterFormatException(
                 "subimage (x+width) is outside raster");
         }
         if (y < 0 || y >= height) {
             throw new RasterFormatException("subimage y is outside raster");
         }
-        if (y + h > height) {
+        if (height - h < y) {
             throw new RasterFormatException(
                 "subimage (y+height) is outside raster");
         }
@@ -145,7 +145,7 @@ public class ImageBuilder {
      *
      * @param width image width (must be greater than zero)
      * @param height image height (must be greater than zero)
-     * @throws RasterFormatException if {@code width} or {@code height} are equal or less than zero
+     * @throws RasterFormatException if {@code width} or {@code height} are equal or less than zero, or if they are too large
      */
     private void checkDimensions(final int width, final int height) {
         if (width <= 0) {
@@ -153,6 +153,10 @@ public class ImageBuilder {
         }
         if (height <= 0) {
             throw new RasterFormatException("zero or negative height value");
+        }
+        // Check for overflow
+        if (width * height < 0) {
+            throw new RasterFormatException("too large width or height value");
         }
     }
 

--- a/src/main/java/org/apache/commons/imaging/common/KnownSizeByteArrayBuilder.java
+++ b/src/main/java/org/apache/commons/imaging/common/KnownSizeByteArrayBuilder.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.common;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+
+/**
+ * <b>Internal class</b>
+ *
+ * <p>Builder for a byte array of known size. The main purpose of this class is to
+ * provide a reasonably efficient way to create a byte array of a certain known size
+ * without eagerly allocating an array of that size, since that could be abused to
+ * cause a denial of service attack if the desired array lenght can be controlled
+ * by a malicious user.
+ *
+ * <p>This class is similar to {@link ByteArrayOutputStream} respectively {@link UnsynchronizedByteArrayOutputStream}
+ * with the main difference that it is most likely more efficient because
+ * <ul>
+ *   <li>it knows the expected byte array length in advance (which is not the same
+ *       as an 'initial capacity') and can therefore allocate temporary byte arrays more
+ *       efficiently
+ *   <li>it does not use any (redundant) synchronization
+ *   <li>it is only single-use and can return the internal temporary byte array
+ *       without having to create any copies
+ * </ul>
+ */
+public class KnownSizeByteArrayBuilder {
+    // See also https://stackoverflow.com/q/3038392
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 10;
+    static final int INITIAL_SECTION_SIZE = 4096;
+
+    private final int expectedSize;
+
+    /** Total number of bytes added so far */
+    private int addedBytesCount = 0;
+    private List<byte[]> sections = new ArrayList<>();
+    /** Current section where bytes are added to; {@code null} if final byte array has already been created */
+    private byte[] currentSection;
+    /** End index (exclusive) of {@link #currentSection}, respectively start index of next write */
+    private int currentSectionEnd = 0;
+
+    /**
+     * @param expectedSize The expected final array size; the number of bytes must
+     *      not be greater than this, but it may be lower, see {@link #createByteArray(boolean)}
+     */
+    public KnownSizeByteArrayBuilder(int expectedSize) {
+        if (expectedSize < 0 || expectedSize > MAX_ARRAY_SIZE) {
+            throw new IllegalArgumentException("Invalid size: " + expectedSize);
+        }
+        Allocator.checkByteArray(expectedSize);
+
+        this.expectedSize = expectedSize;
+
+        currentSection = new byte[Math.min(expectedSize, INITIAL_SECTION_SIZE)];
+        sections.add(currentSection);
+    }
+
+    private void checkByteArrayCreated() {
+        if (currentSection == null) {
+            throw new IllegalStateException("Byte array has already been created");
+        }
+    }
+
+    private void ensureSpaceInCurrentSection() {
+        if (currentSectionEnd >= currentSection.length) {
+            int nextSectionSize = currentSection.length * 2;
+            // In case of overflow or if next section would be equal or larger than remaining expected,
+            // directly create final byte array
+            if (nextSectionSize < 0 || nextSectionSize >= (expectedSize - addedBytesCount)) {
+                currentSection = new byte[expectedSize];
+
+                int copyStartPos = 0;
+                for (byte[] section : sections) {
+                    System.arraycopy(section, 0, currentSection, copyStartPos, section.length);
+                    copyStartPos += section.length;
+                }
+                // Won't be used anymore; also let garbage collection collect the sections
+                sections = null;
+                currentSectionEnd = copyStartPos;
+            } else {
+                currentSection = new byte[nextSectionSize];
+                sections.add(currentSection);
+                currentSectionEnd = 0;
+            }
+        }
+    }
+
+    /**
+     * Returns the number of so far added bytes.
+     */
+    public int getAddedBytesCount() {
+        return addedBytesCount;
+    }
+
+    /**
+     * Add the number of expected bytes from the input stream.
+     *
+     * @throws EOFException If the input stream provides less than the expected number of bytes
+     */
+    public void addAllBytesFrom(InputStream in) throws IOException {
+        checkByteArrayCreated();
+
+        while (true) {
+            int missingBytesCount = expectedSize - addedBytesCount;
+            if (missingBytesCount <= 0) {
+                return;
+            }
+
+            ensureSpaceInCurrentSection();
+
+            int maxRead = Math.min(missingBytesCount, currentSection.length - currentSectionEnd);
+            int readCount = in.read(currentSection, currentSectionEnd, maxRead);
+            if (readCount < 0) {
+                throw new EOFException("Unexpected EOF; was expecting more bytes");
+            }
+            if (readCount > maxRead) {
+                throw new RuntimeException("Bad InputStream implementation read more bytes than requested: " + in.toString());
+            }
+            addedBytesCount += readCount;
+            currentSectionEnd += readCount;
+        }
+    }
+
+    /**
+     * Adds a single byte.
+     *
+     * @throws IllegalStateException If all expected bytes have already been added
+     */
+    public void addByte(byte b) {
+        checkByteArrayCreated();
+
+        if (addedBytesCount >= expectedSize) {
+            throw new IllegalStateException("Already added all expected bytes");
+        }
+
+        ensureSpaceInCurrentSection();
+        currentSection[currentSectionEnd] = b;
+        currentSectionEnd++;
+        addedBytesCount++;
+    }
+
+    /**
+     * Adds bytes from an array.
+     *
+     * @throws IllegalStateException If {@code length} is greater than the remaining expected bytes
+     */
+    public void addBytes(byte[] bytes, int start, int length) {
+        if (start < 0 || length < 0 || bytes.length - length < start) {
+            throw new IllegalArgumentException("Bad start or length value");
+        }
+
+        if (length == 0) {
+            return;
+        }
+        if (length > expectedSize - addedBytesCount) {
+            throw new IllegalStateException("Trying to add more bytes than expected");
+        }
+
+        do {
+            ensureSpaceInCurrentSection();
+            int copyCount = Math.min(length, currentSection.length - currentSectionEnd);
+            System.arraycopy(bytes, start, currentSection, currentSectionEnd, copyCount);
+            currentSectionEnd += copyCount;
+            addedBytesCount += copyCount;
+
+            start += copyCount;
+            length -= copyCount;
+        } while (length > 0);
+    }
+
+    /**
+     * Creates the final byte array. This method can only be called at most once;
+     * afterwards none of the other methods of this class can be called anymore.
+     *
+     * @param allowSmallerThanExpected Whether to allow creating the array even
+     *      if not all expected bytes (as specified originally for the constructor)
+     *      have been added yet
+     */
+    public byte[] createByteArray(boolean allowSmallerThanExpected) {
+        checkByteArrayCreated();
+
+        byte[] resultArray;
+
+        if (addedBytesCount >= expectedSize) {
+            // Current section contains complete content
+            resultArray = currentSection;
+        } else if (allowSmallerThanExpected) {
+            // Check if sections contains only currentSection
+            if (sections == null || sections.size() == 1) {
+                resultArray = Arrays.copyOf(currentSection, currentSectionEnd);
+            } else {
+                resultArray = new byte[addedBytesCount];
+
+                int copyStartPos = 0;
+                // Copy the complete content of all sections except the last (= currentSection)
+                for (int sectionIndex = 0; sectionIndex < sections.size() - 1; sectionIndex++) {
+                    byte[] section = sections.get(sectionIndex);
+                    System.arraycopy(section, 0, resultArray, copyStartPos, section.length);
+                    copyStartPos += section.length;
+                }
+
+                System.arraycopy(currentSection, 0, resultArray, copyStartPos, currentSectionEnd);
+            }
+        } else {
+            throw new IllegalStateException("Not all bytes have been added yet");
+        }
+
+        currentSection = null;
+        sections = null;
+        return resultArray;
+    }
+
+    /**
+     * Creates the final byte array; must only be called once.
+     *
+     * <p>This is a convenience methods which calls {@link #createByteArray(boolean) createByteArray(false)}.
+     */
+    public byte[] createByteArray() {
+        return createByteArray(false);
+    }
+
+    /**
+     * Creates an {@link OutputStream} which can be used to add bytes to this builder.
+     * This is mainly intended for cases when working with an API which expects an {@code OutputStream};
+     * in all other cases prefer one of the other methods of this class.
+     */
+    public OutputStream asOutputStream() {
+        return new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                addByte((byte) b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                addBytes(b, off, len);
+            }
+        };
+    }
+}

--- a/src/main/java/org/apache/commons/imaging/common/PackBits.java
+++ b/src/main/java/org/apache/commons/imaging/common/PackBits.java
@@ -27,7 +27,7 @@ public class PackBits {
     public byte[] compress(final byte[] bytes) throws IOException {
         // max length 1 extra byte for every 128
         try (UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder()
-                .setBufferSize(Allocator.checkByteArray(bytes.length * 2))
+                .setBufferSize(Allocator.checkByteArrayTrusted(bytes.length * 2))
                 .get()) {
             int ptr = 0;
             while (ptr < bytes.length) {

--- a/src/main/java/org/apache/commons/imaging/common/ZlibDeflate.java
+++ b/src/main/java/org/apache/commons/imaging/common/ZlibDeflate.java
@@ -47,7 +47,7 @@ public class ZlibDeflate {
      * @see DeflaterOutputStream
      */
     public static byte[] compress(final byte[] bytes) throws ImagingException {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream(Allocator.checkByteArray(bytes.length / 2));
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(Allocator.checkByteArrayTrusted(bytes.length / 2));
         try (DeflaterOutputStream compressOut = new DeflaterOutputStream(out)) {
             compressOut.write(bytes);
         } catch (final IOException e) {

--- a/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/dcx/DcxImageParser.java
@@ -158,7 +158,7 @@ public class DcxImageParser extends ImageParser<PcxImagingParameters> {
         try (InputStream is = byteSource.getInputStream()) {
             final int id = read4Bytes("Id", is, "Not a Valid DCX File", getByteOrder());
             final int size = 1024;
-            final List<Long> pageTable = Allocator.arrayList(size);
+            final List<Long> pageTable = Allocator.arrayListTrusted(size);
             for (int i = 0; i < size; i++) {
                 final long pageOffset = 0xFFFFffffL & read4Bytes("PageTable", is, "Not a Valid DCX File", getByteOrder());
                 if (pageOffset == 0) {

--- a/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/gif/GifImageParser.java
@@ -175,7 +175,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
             throw new ImagingException("GIF: Invalid amount of Graphic Control Extensions");
         }
 
-        final List<GifImageData> imageData = Allocator.arrayList(descriptors.size());
+        final List<GifImageData> imageData = Allocator.arrayListWithCapacityFor(descriptors);
         for(int i = 0; i < descriptors.size(); i++) {
             final ImageDescriptor descriptor = descriptors.get(i);
             if (descriptor == null) {
@@ -235,7 +235,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
         }
 
         final List<GifImageData> imageData = findAllImageData(imageContents);
-        final List<BufferedImage> result = Allocator.arrayList(imageData.size());
+        final List<BufferedImage> result = Allocator.arrayListWithCapacityFor(imageData);
         for(final GifImageData id : imageData) {
             result.add(getBufferedImage(ghi, id, imageContents.globalColorTable));
         }
@@ -347,7 +347,8 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
         }
         final int length = bytes.length / 3;
 
-        final int[] result = Allocator.intArray(length);
+        // Trusted because length is based on length of existing array
+        final int[] result = Allocator.intArrayTrusted(length);
 
         for (int i = 0; i < length; i++) {
             final int red = 0xff & bytes[(i * 3) + 0];
@@ -490,7 +491,7 @@ public class GifImageParser extends ImageParser<GifImagingParameters> implements
         }
 
         final List<GifImageData> imageData = findAllImageData(imageContents);
-        final List<GifImageMetadataItem> metadataItems = Allocator.arrayList(imageData.size());
+        final List<GifImageMetadataItem> metadataItems = Allocator.arrayListWithCapacityFor(imageData);
         for(final GifImageData id : imageData) {
             final DisposalMethod disposalMethod = createDisposalMethodFromIntValue(id.gce.dispose);
             metadataItems.add(new GifImageMetadataItem(id.gce.delay, id.descriptor.imageLeftPosition, id.descriptor.imageTopPosition, disposalMethod));

--- a/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/ico/IcoImageParser.java
@@ -438,7 +438,7 @@ public class IcoImageParser extends ImageParser<IcoImagingParameters> {
                 : colorsUsed);
         final int bitmapSize = 14 + 56 + restOfFile.length;
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream(Allocator.checkByteArray(bitmapSize));
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream(Allocator.checkByteArrayTrusted(bitmapSize));
         try (BinaryOutputStream bos = BinaryOutputStream.littleEndian(baos)) {
             bos.write('B');
             bos.write('M');

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/JpegImageParser.java
@@ -123,7 +123,8 @@ public class JpegImageParser extends ImageParser<JpegImagingParameters> implemen
             }
         }
 
-        final byte[] result = Allocator.byteArray(total);
+        // Trusted because length is based on length of existing arrays
+        final byte[] result = Allocator.byteArrayTrusted(total);
         int progress = 0;
 
         for (final App2Segment segment : segments) {
@@ -459,7 +460,7 @@ public class JpegImageParser extends ImageParser<JpegImagingParameters> implemen
 
         final List<Segment> commentSegments = readSegments(byteSource,
                 new int[] { JpegConstants.COM_MARKER}, false);
-        final List<String> comments = Allocator.arrayList(commentSegments.size());
+        final List<String> comments = Allocator.arrayListWithCapacityFor(commentSegments);
         for (final Segment commentSegment : commentSegments) {
             final ComSegment comSegment = (ComSegment) commentSegment;
             comments.add(new String(comSegment.getComment(), StandardCharsets.UTF_8));

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoder.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/decoder/JpegDecoder.java
@@ -109,7 +109,8 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
         final List<Integer> intervalStarts = getIntervalStartPositions(scanPayload);
         // get number of intervals in payload to init an array of appropriate length
         final int intervalCount = intervalStarts.size();
-        final JpegInputStream[] streams = Allocator.array(intervalCount, JpegInputStream[]::new, JpegInputStream.SHALLOW_SIZE);
+        // Trusted because length is based on size of existing List
+        final JpegInputStream[] streams = Allocator.arrayTrusted(intervalCount, JpegInputStream[]::new, JpegInputStream.SHALLOW_SIZE);
         for (int i = 0; i < intervalCount; i++) {
             final int from = intervalStarts.get(i);
             int to;
@@ -144,7 +145,7 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
     private Block[] allocateMcuMemory() throws ImagingException {
         final Block[] mcu = Allocator.array(sosSegment.numberOfComponents, Block[]::new, Block.SHALLOW_SIZE);
         for (int i = 0; i < sosSegment.numberOfComponents; i++) {
-            final SosSegment.Component scanComponent = sosSegment.getComponents(i);
+            final SosSegment.Component scanComponent = sosSegment.getComponent(i);
             SofnSegment.Component frameComponent = null;
             for (int j = 0; j < sofnSegment.numberOfComponents; j++) {
                 if (sofnSegment.getComponents(j).componentIdentifier == scanComponent.scanComponentSelector) {
@@ -208,7 +209,7 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
     private void readMcu(final JpegInputStream is, final int[] preds, final Block[] mcu)
             throws ImagingException {
         for (int i = 0; i < sosSegment.numberOfComponents; i++) {
-            final SosSegment.Component scanComponent = sosSegment.getComponents(i);
+            final SosSegment.Component scanComponent = sosSegment.getComponent(i);
             SofnSegment.Component frameComponent = null;
             for (int j = 0; j < sofnSegment.numberOfComponents; j++) {
                 if (sofnSegment.getComponents(j).componentIdentifier == scanComponent.scanComponentSelector) {
@@ -379,9 +380,9 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
                 }
                 quantizationTables[table.destinationIdentifier] = table;
                 final int mSize = 64;
-                final int[] quantizationMatrixInt = Allocator.intArray(mSize);
+                final int[] quantizationMatrixInt = Allocator.intArrayTrusted(mSize);
                 ZigZag.zigZagToBlock(table.getElements(), quantizationMatrixInt);
-                final float[] quantizationMatrixFloat = Allocator.floatArray(mSize);
+                final float[] quantizationMatrixFloat = Allocator.floatArrayTrusted(mSize);
                 for (int j = 0; j < mSize; j++) {
                     quantizationMatrixFloat[j] = quantizationMatrixInt[j];
                 }
@@ -423,7 +424,8 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
             // the payload contains the entropy-encoded segments (or ECS) divided by RST markers
             // or only one ECS if the entropy-encoded data is not divided by RST markers
             // length of payload = length of image data - length of data already read
-            final int[] scanPayload = Allocator.intArray(imageData.length - segmentLength);
+            // Trusted because length is based on length of existing array
+            final int[] scanPayload = Allocator.intArrayTrusted(imageData.length - segmentLength);
             int payloadReadCount = 0;
             while (payloadReadCount < scanPayload.length) {
                 scanPayload[payloadReadCount] = is.read();
@@ -444,7 +446,8 @@ public class JpegDecoder extends BinaryFileParser implements JpegUtils.Visitor {
             final int xMCUs = (sofnSegment.width + hSize - 1) / hSize;
             final int yMCUs = (sofnSegment.height + vSize - 1) / vSize;
             final Block[] mcu = allocateMcuMemory();
-            final Block[] scaledMCU = Allocator.array(mcu.length, Block[]::new, Block.SHALLOW_SIZE);
+            // Trusted because length is based on length of existing array
+            final Block[] scaledMCU = Allocator.arrayTrusted(mcu.length, Block[]::new, Block.SHALLOW_SIZE);
             Arrays.setAll(scaledMCU, i -> new Block(hSize, vSize));
             final int[] preds = Allocator.intArray(sofnSegment.numberOfComponents);
             ColorModel colorModel;

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParser.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -86,7 +85,8 @@ public class IptcParser extends BinaryFileParser {
         }
         // check if encoding is a escape sequence
         // normalize encoding byte sequence
-        final byte[] codedCharsetNormalized = Allocator.byteArray(codedCharset.length);
+        // Trusted because length is based on length of existing array
+        final byte[] codedCharsetNormalized = Allocator.byteArrayTrusted(codedCharset.length);
         int j = 0;
         for (final byte element : codedCharset) {
             if (element != ' ') {
@@ -94,7 +94,7 @@ public class IptcParser extends BinaryFileParser {
             }
         }
 
-        if (Objects.deepEquals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE)) {
+        if (Arrays.equals(codedCharsetNormalized, CHARACTER_ESCAPE_SEQUENCE)) {
             return StandardCharsets.UTF_8;
         }
         return DEFAULT_CHARSET;

--- a/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegment.java
+++ b/src/main/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegment.java
@@ -21,6 +21,8 @@ import static org.apache.commons.imaging.common.BinaryFunctions.readByte;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -44,7 +46,7 @@ public class SosSegment extends Segment {
 
     private static final Logger LOGGER = Logger.getLogger(SosSegment.class.getName());
     public final int numberOfComponents;
-    private final Component[] components;
+    private final List<Component> components;
     public final int startOfSpectralSelection;
     public final int endOfSpectralSelection;
     public final int successiveApproximationBitHigh;
@@ -69,7 +71,7 @@ public class SosSegment extends Segment {
         // Debug.debug("number_of_components_in_scan",
         // numberOfComponents);
 
-        components = Allocator.array(numberOfComponents, Component[]::new, Component.SHALLOW_SIZE);
+        List<Component> components = Allocator.arrayList(numberOfComponents);
         for (int i = 0; i < numberOfComponents; i++) {
             final int scanComponentSelector = readByte("scanComponentSelector", is, "Not a Valid JPEG File");
             // Debug.debug("scanComponentSelector", scanComponentSelector);
@@ -82,9 +84,10 @@ public class SosSegment extends Segment {
 
             final int dcCodingTableSelector = (acDcEntropyCodingTableSelector >> 4) & 0xf;
             final int acCodingTableSelector = acDcEntropyCodingTableSelector & 0xf;
-            components[i] = new Component(scanComponentSelector,
-                    dcCodingTableSelector, acCodingTableSelector);
+            components.add(new Component(scanComponentSelector,
+                    dcCodingTableSelector, acCodingTableSelector));
         }
+        this.components = Collections.unmodifiableList(components);
 
         startOfSpectralSelection = readByte("startOfSpectralSelection", is,
                 "Not a Valid JPEG File");
@@ -102,11 +105,11 @@ public class SosSegment extends Segment {
     }
 
     /**
-     * Returns a copy of all the components.
+     * Returns an unmodifiable list of all components.
      * @return all the components
      */
-    public Component[] getComponents() {
-        return components.clone();
+    public List<Component> getComponents() {
+        return Collections.unmodifiableList(components);
     }
 
     /**
@@ -114,8 +117,8 @@ public class SosSegment extends Segment {
      * @param index the component index
      * @return the component
      */
-    public Component getComponents(final int index) {
-        return components[index];
+    public Component getComponent(final int index) {
+        return components.get(index);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxWriter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxWriter.java
@@ -266,7 +266,8 @@ class PcxWriter {
     private void writePixels32(final BufferedImage src, final int bytesPerLine,
             final BinaryOutputStream bos) throws IOException {
 
-        final int[] rgbs = Allocator.intArray(src.getWidth());
+        // Trusted because length is based on size of existing image
+        final int[] rgbs = Allocator.intArrayTrusted(src.getWidth());
         final byte[] plane = Allocator.byteArray(4 * bytesPerLine);
         for (int y = 0; y < src.getHeight(); y++) {
             src.getRGB(0, y, src.getWidth(), 1, rgbs, 0, src.getWidth());

--- a/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/PngImageParser.java
@@ -330,7 +330,7 @@ public class PngImageParser extends ImageParser<PngImagingParameters>  implement
     public List<String> getChunkTypes(final InputStream is)
             throws ImagingException, IOException {
         final List<PngChunk> chunks = readChunks(is, null, false);
-        final List<String> chunkTypes = Allocator.arrayList(chunks.size());
+        final List<String> chunkTypes = Allocator.arrayListWithCapacityFor(chunks);
         for (final PngChunk chunk : chunks) {
             chunkTypes.add(getChunkTypeName(chunk.getChunkType()));
         }
@@ -437,8 +437,9 @@ public class PngImageParser extends ImageParser<PngImagingParameters>  implement
         final List<PngChunk> iTXts = filterChunks(chunks, ChunkType.iTXt);
 
         final int chunkCount = tEXts.size() + zTXts.size() + iTXts.size();
-        final List<String> comments = Allocator.arrayList(chunkCount);
-        final List<PngText> textChunks = Allocator.arrayList(chunkCount);
+        // Trusted because size is based on sizes of existing lists
+        final List<String> comments = Allocator.arrayListTrusted(chunkCount);
+        final List<PngText> textChunks = Allocator.arrayListTrusted(chunkCount);
 
         for (final PngChunk tEXt : tEXts) {
             final PngChunkText pngChunktEXt = (PngChunkText) tEXt;

--- a/src/main/java/org/apache/commons/imaging/formats/png/ScanExpediter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/ScanExpediter.java
@@ -210,7 +210,8 @@ abstract class ScanExpediter {
             final int bytesPerPixel) throws ImagingException, IOException {
         final ScanlineFilter filter = getScanlineFilter(filterType, bytesPerPixel);
 
-        final byte[] dst = Allocator.byteArray(src.length);
+        // Trusted because length is based on length of existing array
+        final byte[] dst = Allocator.byteArrayTrusted(src.length);
         filter.unfilter(src, dst, prev);
         return dst;
     }

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkIccp.java
@@ -82,7 +82,8 @@ public class PngChunkIccp extends PngChunk {
         compressionMethod = bytes[index + 1];
 
         final int compressedProfileLength = bytes.length - (index + 1 + 1);
-        compressedProfile = Allocator.byteArray(compressedProfileLength);
+        // Trusted because length is based on length of existing array
+        compressedProfile = Allocator.byteArrayTrusted(compressedProfileLength);
         System.arraycopy(bytes, index + 1 + 1, compressedProfile, 0, compressedProfileLength);
 
         if (LOGGER.isLoggable(Level.FINEST)) {

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkItxt.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkItxt.java
@@ -77,7 +77,8 @@ public class PngChunkItxt extends PngTextChunk {
         if (compressed) {
             final int compressedTextLength = bytes.length - index;
 
-            final byte[] compressedText = Allocator.byteArray(compressedTextLength);
+            // Trusted because length is based on length of existing array
+            final byte[] compressedText = Allocator.byteArrayTrusted(compressedTextLength);
             System.arraycopy(bytes, index, compressedText, 0, compressedTextLength);
 
             text = new String(IOUtils.toByteArray(new InflaterInputStream(new ByteArrayInputStream(compressedText))), StandardCharsets.UTF_8);

--- a/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkZtxt.java
+++ b/src/main/java/org/apache/commons/imaging/formats/png/chunks/PngChunkZtxt.java
@@ -46,7 +46,8 @@ public class PngChunkZtxt extends PngTextChunk {
         }
 
         final int compressedTextLength = bytes.length - index;
-        final byte[] compressedText = Allocator.byteArray(compressedTextLength);
+        // Trusted because length is based on length of existing array
+        final byte[] compressedText = Allocator.byteArrayTrusted(compressedTextLength);
         System.arraycopy(bytes, index, compressedText, 0, compressedTextLength);
 
         text = new String(IOUtils.toByteArray(new InflaterInputStream(new ByteArrayInputStream(compressedText))), StandardCharsets.ISO_8859_1);

--- a/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/CompressedDataReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/CompressedDataReader.java
@@ -61,7 +61,8 @@ public class CompressedDataReader implements DataReader {
         final int depth = header.depth;
 
         final int channelCount = dataParser.getBasicChannelsCount();
-        final int[][][] data = new int[Allocator.check(channelCount)][Allocator.check(height)][];
+        Allocator.check(Math.multiplyExact(channelCount, height), Integer.BYTES);
+        final int[][][] data = new int[channelCount][height][];
         // channels[0] =
         for (int channel = 0; channel < channelCount; channel++) {
             for (int y = 0; y < height; y++) {

--- a/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/UncompressedDataReader.java
+++ b/src/main/java/org/apache/commons/imaging/formats/psd/datareaders/UncompressedDataReader.java
@@ -51,8 +51,8 @@ public class UncompressedDataReader implements DataReader {
         final MyBitInputStream mbis = new MyBitInputStream(is, ByteOrder.BIG_ENDIAN, false);
         // we want all samples to be bytes
         try (BitsToByteInputStream bbis = new BitsToByteInputStream(mbis, 8)) {
-            final int[][][] data = new int[Allocator.check(channelCount)][Allocator
-                    .check(height)][Allocator.check(width)];
+            Allocator.check(Math.multiplyExact(channelCount, Math.multiplyExact(height, width)), Integer.BYTES);
+            final int[][][] data = new int[channelCount][height][width];
             for (int channel = 0; channel < channelCount; channel++) {
                 for (int y = 0; y < height; y++) {
                     for (int x = 0; x < width; x++) {

--- a/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeInfo.java
+++ b/src/main/java/org/apache/commons/imaging/formats/rgbe/RgbeInfo.java
@@ -108,7 +108,8 @@ class RgbeInfo implements Closeable {
         final byte[] scanLineBytes = ByteConversions.toBytes((short) wd,
                 ByteOrder.BIG_ENDIAN);
         final byte[] rgbe = Allocator.byteArray(wd * 4);
-        final float[][] out = new float[3][Allocator.check(wd * ht)];
+        Allocator.check(Math.multiplyExact(3, Math.multiplyExact(wd, ht)), Float.BYTES);
+        final float[][] out = new float[3][wd * ht];
 
         for (int i = 0; i < ht; i++) {
             BinaryFunctions.readAndVerifyBytes(in, TWO_TWO, "Scan line " + i + " expected to start with 0x2 0x2");

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffDirectory.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffDirectory.java
@@ -19,7 +19,6 @@ package org.apache.commons.imaging.formats.tiff;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -172,8 +171,11 @@ public class TiffDirectory extends TiffElement implements Iterable<TiffField> {
         return headerByteOrder;
     }
 
+    /**
+     * Returns an unmodifiable list of all directory entries.
+     */
     public List<TiffField> getDirectoryEntries() {
-        return new ArrayList<>(entries);
+        return Collections.unmodifiableList(entries);
     }
 
     @Override
@@ -733,7 +735,7 @@ public class TiffDirectory extends TiffElement implements Iterable<TiffField> {
                     + ") != byteCounts.length(" + byteCounts.length + ")");
         }
 
-        final List<ImageDataElement> result = Allocator.arrayList(offsets.length);
+        final List<ImageDataElement> result = Allocator.arrayListTrusted(offsets.length);
         for (int i = 0; i < offsets.length; i++) {
             result.add(new ImageDataElement(offsets[i], byteCounts[i]));
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffField.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffField.java
@@ -156,25 +156,29 @@ public class TiffField {
         }
         if (o instanceof Number[]) {
             final Number[] numbers = (Number[]) o;
-            final double[] result = Allocator.doubleArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final double[] result = Allocator.doubleArrayTrusted(numbers.length);
             Arrays.setAll(result, i -> numbers[i].doubleValue());
             return result;
         }
         if (o instanceof short[]) {
             final short[] numbers = (short[]) o;
-            final double[] result = Allocator.doubleArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final double[] result = Allocator.doubleArrayTrusted(numbers.length);
             Arrays.setAll(result, i -> numbers[i]);
             return result;
         }
         if (o instanceof int[]) {
             final int[] numbers = (int[]) o;
-            final double[] result = Allocator.doubleArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final double[] result = Allocator.doubleArrayTrusted(numbers.length);
             Arrays.setAll(result, i -> numbers[i]);
             return result;
         }
         if (o instanceof float[]) {
             final float[] numbers = (float[]) o;
-            final double[] result = Allocator.doubleArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final double[] result = Allocator.doubleArrayTrusted(numbers.length);
             Arrays.setAll(result, i -> numbers[i]);
             return result;
         }
@@ -220,13 +224,15 @@ public class TiffField {
         }
         if (o instanceof Number[]) {
             final Number[] numbers = (Number[]) o;
-            final int[] result = Allocator.intArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final int[] result = Allocator.intArrayTrusted(numbers.length);
             Arrays.setAll(result, i -> numbers[i].intValue());
             return result;
         }
         if (o instanceof short[]) {
             final short[] numbers = (short[]) o;
-            final int[] result = Allocator.intArray(numbers.length);
+            // Trusted because length is based on length of existing array
+            final int[] result = Allocator.intArrayTrusted(numbers.length);
             Arrays.setAll(result, i ->  0xffff & numbers[i]);
             return result;
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -508,7 +508,8 @@ public class TiffImageParser extends ImageParser<TiffImagingParameters> implemen
         final int bitsPerPixel = bitsPerSample; // assume grayscale;
         // dunno if this handles colormapped images correctly.
 
-        final List<String> comments = Allocator.arrayList(directory.size());
+        // Trusted because `TiffDirectory.size()` reports size of existing List
+        final List<String> comments = Allocator.arrayListTrusted(directory.size());
         for (final TiffField field : directory) {
             final String comment = field.toString();
             comments.add(comment);

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffRasterDataInt.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffRasterDataInt.java
@@ -113,7 +113,8 @@ public class TiffRasterDataInt extends TiffRasterData {
      */
     @Override
     public float[] getData() {
-        final float[] result = Allocator.floatArray(nCells);
+        // Trusted because length is based on length of existing `data` array
+        final float[] result = Allocator.floatArrayTrusted(nCells);
         for (int i = 0; i < nCells; i++) {
             result[i] = data[i];
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAscii.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeAscii.java
@@ -40,7 +40,8 @@ public class FieldTypeAscii extends FieldType {
                 nullCount++;
             }
         }
-        final String[] strings = Allocator.array(nullCount, String[]::new, 24);
+        // Trusted because length is based on length of existing array
+        final String[] strings = Allocator.arrayTrusted(nullCount, String[]::new, 24);
         int stringsAdded = 0;
         strings[0] = ""; // if we have a 0 length string
         int nextStringPos = 0;
@@ -85,15 +86,18 @@ public class FieldTypeAscii extends FieldType {
             throw new ImagingException("Unknown data type: " + o);
         }
         final String[] strings = (String[]) o;
+        final byte[][] stringBytes = new byte[strings.length][];
         int totalLength = 0;
-        for (final String string : strings) {
+        for (int i = 0; i < strings.length; i++) {
+            final String string = strings[i];
             final byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
             totalLength += (bytes.length + 1);
+            stringBytes[i] = bytes;
         }
-        final byte[] result = Allocator.byteArray(totalLength);
+        // Trusted because length is based on length of existing arrays
+        final byte[] result = Allocator.byteArrayTrusted(totalLength);
         int position = 0;
-        for (final String string : strings) {
-            final byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+        for (final byte[] bytes : stringBytes) {
             System.arraycopy(bytes, 0, result, position, bytes.length);
             position += (bytes.length + 1);
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeDouble.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeDouble.java
@@ -49,7 +49,8 @@ public class FieldTypeDouble extends FieldType {
         if (!(o instanceof Double[])) {
             throw new ImagingException("Invalid data", o);
         }
-        final double[] values = Allocator.doubleArray(((Double[]) o).length);
+        // Trusted because length is based on length of existing array
+        final double[] values = Allocator.doubleArrayTrusted(((Double[]) o).length);
         Arrays.setAll(values, i -> ((Double[]) o)[i].doubleValue());
         return ByteConversions.toBytes(values, byteOrder);
     }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeFloat.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeFloat.java
@@ -50,7 +50,8 @@ public class FieldTypeFloat extends FieldType {
             throw new ImagingException("Invalid data", o);
         }
         final Float[] numbers = (Float[]) o;
-        final float[] values = Allocator.floatArray(numbers.length);
+        // Trusted because length is based on length of existing array
+        final float[] values = Allocator.floatArrayTrusted(numbers.length);
         for (int i = 0; i < values.length; i++) {
             values[i] = numbers[i].floatValue();
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeLong.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeLong.java
@@ -51,7 +51,8 @@ public class FieldTypeLong extends FieldType {
             throw new ImagingException("Invalid data", o);
         }
         final Integer[] numbers = (Integer[]) o;
-        final int[] values = Allocator.intArray(numbers.length);
+        // Trusted because length is based on length of existing array
+        final int[] values = Allocator.intArrayTrusted(numbers.length);
         for (int i = 0; i < values.length; i++) {
             values[i] = numbers[i];
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRational.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeRational.java
@@ -57,7 +57,8 @@ public class FieldTypeRational extends FieldType {
         }
         if (o instanceof Number[]) {
             final Number[] numbers = (Number[]) o;
-            final RationalNumber[] rationalNumbers = Allocator.array(numbers.length, RationalNumber[]::new,
+            // Trusted because length is based on length of existing array
+            final RationalNumber[] rationalNumbers = Allocator.arrayTrusted(numbers.length, RationalNumber[]::new,
                     RationalNumber.SHALLOW_SIZE);
             Arrays.setAll(rationalNumbers, RationalNumber::valueOf);
             return ByteConversions.toBytes(rationalNumbers, byteOrder);
@@ -66,7 +67,8 @@ public class FieldTypeRational extends FieldType {
             throw new ImagingException("Invalid data", o);
         }
         final double[] numbers = (double[]) o;
-        final RationalNumber[] rationalNumbers = Allocator.array(numbers.length, RationalNumber[]::new,
+        // Trusted because length is based on length of existing array
+        final RationalNumber[] rationalNumbers = Allocator.arrayTrusted(numbers.length, RationalNumber[]::new,
                 RationalNumber.SHALLOW_SIZE);
         Arrays.setAll(rationalNumbers, RationalNumber::valueOf);
         return ByteConversions.toBytes(rationalNumbers, byteOrder);

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeShort.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/fieldtypes/FieldTypeShort.java
@@ -50,7 +50,8 @@ public class FieldTypeShort extends FieldType {
             throw new ImagingException("Invalid data", o);
         }
         final Short[] numbers = (Short[]) o;
-        final short[] values = Allocator.shortArray(numbers.length);
+        // Trusted because length is based on length of existing array
+        final short[] values = Allocator.shortArrayTrusted(numbers.length);
         for (int i = 0; i < values.length; i++) {
             values[i] = numbers[i].shortValue();
         }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoAscii.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoAscii.java
@@ -42,7 +42,8 @@ public class TagInfoAscii extends TagInfo {
                 nullCount++;
             }
         }
-        final String[] strings = Allocator.array(nullCount + 1, String[]::new, 24);
+        // Trusted because length is based on length of existing array
+        final String[] strings = Allocator.arrayTrusted(nullCount + 1, String[]::new, 24);
         int stringsAdded = 0;
         strings[0] = ""; // if we have a 0 length string
         int nextStringPos = 0;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoGpsText.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/taginfos/TagInfoGpsText.java
@@ -90,7 +90,8 @@ public final class TagInfoGpsText extends TagInfo {
             final String decodedAscii = new String(asciiBytes, TEXT_ENCODING_ASCII.encodingName);
             if (decodedAscii.equals(s)) {
                 // no unicode/non-ascii values.
-                final byte[] result = Allocator.byteArray(asciiBytes.length + TEXT_ENCODING_ASCII.prefix.length);
+                // Trusted because length is based on length of existing arrays
+                final byte[] result = Allocator.byteArrayTrusted(asciiBytes.length + TEXT_ENCODING_ASCII.prefix.length);
                 System.arraycopy(TEXT_ENCODING_ASCII.prefix, 0, result, 0, TEXT_ENCODING_ASCII.prefix.length);
                 System.arraycopy(asciiBytes, 0, result, TEXT_ENCODING_ASCII.prefix.length, asciiBytes.length);
                 return result;
@@ -103,7 +104,8 @@ public final class TagInfoGpsText extends TagInfo {
                 encoding = TEXT_ENCODING_UNICODE_LE;
             }
             final byte[] unicodeBytes = s.getBytes(encoding.encodingName);
-            final byte[] result = Allocator.byteArray(unicodeBytes.length + encoding.prefix.length);
+            // Trusted because length is based on length of existing arrays
+            final byte[] result = Allocator.byteArrayTrusted(unicodeBytes.length + encoding.prefix.length);
             System.arraycopy(encoding.prefix, 0, result, 0, encoding.prefix.length);
             System.arraycopy(unicodeBytes, 0, result, encoding.prefix.length, unicodeBytes.length);
             return result;

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/ImageDataOffsets.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/ImageDataOffsets.java
@@ -30,7 +30,8 @@ class ImageDataOffsets {
         this.imageDataOffsets = imageDataOffsets;
         this.imageDataOffsetsField = imageDataOffsetsField;
 
-        outputItems = Allocator.array(imageData.length, TiffOutputItem[]::new, TiffOutputItem.Value.SHALLOW_SIZE);
+        // Trusted because length is based on length of existing array
+        outputItems = Allocator.arrayTrusted(imageData.length, TiffOutputItem[]::new, TiffOutputItem.Value.SHALLOW_SIZE);
         Arrays.setAll(outputItems, i -> new TiffOutputItem.Value("TIFF image data", imageData[i].getData()));
 
     }

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectory.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/write/TiffOutputDirectory.java
@@ -635,8 +635,9 @@ public final class TiffOutputDirectory extends TiffOutputItem implements Iterabl
 
             // TiffOutputField imageDataOffsetsField = null;
 
-            final int[] imageDataOffsets = Allocator.intArray(imageData.length);
-            final int[] imageDataByteCounts = Allocator.intArray(imageData.length);
+            // Trusted because length is based on length of existing array
+            final int[] imageDataOffsets = Allocator.intArrayTrusted(imageData.length);
+            final int[] imageDataByteCounts = Allocator.intArrayTrusted(imageData.length);
             Arrays.setAll(imageDataByteCounts, i -> imageData[i].length);
 
             // Append imageData-related fields to first directory

--- a/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/xpm/XpmImageParser.java
@@ -507,7 +507,8 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
         WritableRaster raster;
         int bpp;
         if (xpmHeader.palette.size() <= (1 << 8)) {
-            final int[] palette = Allocator.intArray(xpmHeader.palette.size());
+            // Trusted because length is based on size of existing Map
+            final int[] palette = Allocator.intArrayTrusted(xpmHeader.palette.size());
             for (final Entry<Object, PaletteEntry> entry : xpmHeader.palette.entrySet()) {
                 final PaletteEntry paletteEntry = entry.getValue();
                 palette[paletteEntry.index] = paletteEntry.getBestArgb();
@@ -519,11 +520,12 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
             int pixelStride = bands;
             int size = scanlineStride * (xpmHeader.height - 1) + // first (h - 1) scans
                     pixelStride * xpmHeader.width; // last scan
-            Allocator.check(Byte.SIZE, size);
+            Allocator.check(size, Byte.SIZE);
             raster = Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, xpmHeader.width, xpmHeader.height, bands, null);
             bpp = 8;
         } else if (xpmHeader.palette.size() <= (1 << 16)) {
-            final int[] palette = Allocator.intArray(xpmHeader.palette.size());
+            // Trusted because length is based on size of existing Map
+            final int[] palette = Allocator.intArrayTrusted(xpmHeader.palette.size());
             for (final Entry<Object, PaletteEntry> entry : xpmHeader.palette.entrySet()) {
                 final PaletteEntry paletteEntry = entry.getValue();
                 palette[paletteEntry.index] = paletteEntry.getBestArgb();
@@ -535,12 +537,12 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
             int pixelStride = bands;
             int size = scanlineStride * (xpmHeader.height - 1) + // first (h - 1) scans
                     pixelStride * xpmHeader.width; // last scan
-            Allocator.check(Short.SIZE, size);
+            Allocator.check(size, Short.SIZE);
             raster = Raster.createInterleavedRaster(DataBuffer.TYPE_USHORT, xpmHeader.width, xpmHeader.height, bands, null);
             bpp = 16;
         } else {
             colorModel = new DirectColorModel(32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000);
-            Allocator.check(Integer.SIZE, xpmHeader.width * xpmHeader.height);
+            Allocator.check(Math.multiplyExact(xpmHeader.width, xpmHeader.height), Integer.SIZE);
             raster = Raster.createPackedRaster(DataBuffer.TYPE_INT, xpmHeader.width, xpmHeader.height,
                     new int[] { 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 }, null);
             bpp = 32;
@@ -587,7 +589,8 @@ public class XpmImageParser extends ImageParser<XpmImagingParameters> {
     private String toColor(final int color) {
         final String hex = Integer.toHexString(color);
         if (hex.length() < 6) {
-            final char[] zeroes = Allocator.charArray(6 - hex.length());
+            // Trusted because length is based on length of existing String
+            final char[] zeroes = Allocator.charArrayTrusted(6 - hex.length());
             Arrays.fill(zeroes, '0');
             return "#" + new String(zeroes) + hex;
         }

--- a/src/main/java/org/apache/commons/imaging/icc/IccProfileParser.java
+++ b/src/main/java/org/apache/commons/imaging/icc/IccProfileParser.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -241,8 +242,7 @@ public class IccProfileParser extends BinaryFileParser {
 
         final int tagCount = read4Bytes("TagCount", is, "Not a Valid ICC Profile", getByteOrder());
 
-        // List tags = new ArrayList();
-        final IccTag[] tags = Allocator.array(tagCount, IccTag[]::new, IccTag.SHALLOW_SIZE);
+        final List<IccTag> tags = Allocator.arrayList(tagCount);
 
         for (int i = 0; i < tagCount; i++) {
             final int tagSignature = read4Bytes("TagSignature[" + i + "]", is, "Not a Valid ICC Profile",
@@ -270,8 +270,7 @@ public class IccProfileParser extends BinaryFileParser {
 
             final IccTag tag = new IccTag(tagSignature, offsetToData, elementSize, fIccTagType);
             // tag.dump("\t" + i + ": ");
-            tags[i] = tag;
-            // tags .add(tag);
+            tags.add(tag);
         }
 
         // read stream to end, filling cache.
@@ -286,7 +285,7 @@ public class IccProfileParser extends BinaryFileParser {
         final IccProfileInfo result = new IccProfileInfo(data, profileSize, cmmTypeSignature, profileVersion,
                 profileDeviceClassSignature, colorSpace, profileConnectionSpace, profileFileSignature,
                 primaryPlatformSignature, variousFlags, deviceManufacturer, deviceModel, renderingIntent,
-                profileCreatorSignature, null, tags);
+                profileCreatorSignature, null, tags.toArray(new IccTag[0]));
 
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.finest("issRGB: " + result.isSrgb());

--- a/src/main/java/org/apache/commons/imaging/mylzw/MyLzwCompressor.java
+++ b/src/main/java/org/apache/commons/imaging/mylzw/MyLzwCompressor.java
@@ -176,7 +176,7 @@ public class MyLzwCompressor {
     }
 
     public byte[] compress(final byte[] bytes) throws IOException {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(Allocator.checkByteArray(bytes.length));
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(Allocator.checkByteArrayTrusted(bytes.length));
                 MyBitOutputStream bos = new MyBitOutputStream(baos, byteOrder)) {
 
             initializeStringTable();

--- a/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
+++ b/src/main/java/org/apache/commons/imaging/palette/MedianCutQuantizer.java
@@ -57,7 +57,8 @@ public class MedianCutQuantizer {
         final int width = image.getWidth();
         final int height = image.getHeight();
 
-        final int[] row = Allocator.intArray(width);
+        // Trusted because length is based on width of existing image
+        final int[] row = Allocator.intArrayTrusted(width);
         for (int y = 0; y < height; y++) {
             image.getRGB(0, y, width, 1, row, 0, width);
             for (int x = 0; x < width; x++) {
@@ -92,7 +93,8 @@ public class MedianCutQuantizer {
         if (discreteColors <= maxColors) {
             Debug.debug("lossless palette: " + discreteColors);
 
-            final int[] palette = Allocator.intArray(discreteColors);
+            // Trusted because length is based on size of existing Map
+            final int[] palette = Allocator.intArrayTrusted(discreteColors);
             final List<ColorCount> colorCounts = new ArrayList<>(
                     colorMap.values());
 

--- a/src/main/java/org/apache/commons/imaging/palette/PaletteFactory.java
+++ b/src/main/java/org/apache/commons/imaging/palette/PaletteFactory.java
@@ -337,7 +337,7 @@ public class PaletteFactory {
     public Palette makeExactRgbPaletteFancy(final BufferedImage src) {
         // map what rgb values have been used
 
-        final byte[] rgbmap = Allocator.byteArray(256 * 256 * 32);
+        final byte[] rgbmap = Allocator.byteArrayTrusted(256 * 256 * 32);
 
         final int width = src.getWidth();
         final int height = src.getHeight();
@@ -408,7 +408,8 @@ public class PaletteFactory {
             }
         }
 
-        final int[] result = Allocator.intArray(rgbs.size());
+        // Trusted because length is based on size of existing Set
+        final int[] result = Allocator.intArrayTrusted(rgbs.size());
         int next = 0;
         for (final int rgb : rgbs) {
             result[next++] = rgb;

--- a/src/test/java/org/apache/commons/imaging/common/BinaryFunctionsTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/BinaryFunctionsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BinaryFunctionsTest {
+    @ParameterizedTest
+    @ValueSource(ints = {Integer.MIN_VALUE, -1, 6, Integer.MAX_VALUE})
+    void testSlice_Invalid(int length) {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> BinaryFunctions.slice(new byte[5], -4, length));
+        assertEquals("Invalid start or count", e.getMessage());
+
+        e = assertThrows(IllegalArgumentException.class, () -> BinaryFunctions.slice(new byte[5], 0, length));
+        assertEquals("Invalid start or count", e.getMessage());
+    }
+}

--- a/src/test/java/org/apache/commons/imaging/common/KnownSizeByteArrayBuilderTest.java
+++ b/src/test/java/org/apache/commons/imaging/common/KnownSizeByteArrayBuilderTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.common;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class KnownSizeByteArrayBuilderTest {
+    private static byte[] getTestBytes(int length) {
+        byte[] bytes = new byte[length];
+
+        for (int i = 0; i < bytes.length; i++) {
+            // Uses a number > 127 and <= 255 to cover positive and negative byte values
+            // Number is a prime number to avoid matching internal section sizes of builder
+            bytes[i] = (byte) (i % 251);
+        }
+
+        return bytes;
+    }
+
+    @Test
+    void testEmpty() {
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(0);
+        assertArrayEquals(new byte[0], builder.createByteArray());
+    }
+
+    @Test
+    void testInvalidExpected() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new KnownSizeByteArrayBuilder(-1));
+        assertEquals("Invalid size: -1", e.getMessage());
+
+        e = assertThrows(IllegalArgumentException.class, () -> new KnownSizeByteArrayBuilder(Integer.MAX_VALUE));
+        assertEquals("Invalid size: " + Integer.MAX_VALUE, e.getMessage());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(ints = {
+        1,
+        10,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE * 2,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE * 2 + 100,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE * 5 + 100,
+    })
+    void testAddByte(int expectedSize) {
+        byte[] testData = getTestBytes(expectedSize);
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(expectedSize);
+        assertEquals(0, builder.getAddedBytesCount());
+
+        for (byte b : testData) {
+            builder.addByte(b);
+        }
+
+        assertEquals(expectedSize, builder.getAddedBytesCount());
+        byte[] actualArray = builder.createByteArray();
+        assertArrayEquals(testData, actualArray);
+    }
+
+    @Test
+    void testAddByte_MoreThanExpected() {
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(1);
+        builder.addByte((byte) 1);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.addByte((byte) 1));
+        assertEquals("Already added all expected bytes", e.getMessage());
+    }
+
+    @Test
+    void testAddBytes() {
+        byte[] testData = getTestBytes(KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100);
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(testData.length);
+
+        int index = 0;
+        int nextAddLength = 0;
+
+        while (index < testData.length) {
+            byte[] array = testData.clone();
+            builder.addBytes(array, index, nextAddLength);
+
+            assertArrayEquals(testData, array, "Builder modified content of given array");
+
+            index += nextAddLength;
+            nextAddLength = Math.min((nextAddLength + 1) * 2, testData.length - index);
+        }
+
+        assertArrayEquals(testData, builder.createByteArray());
+    }
+
+    @Test
+    void testAddBytes_MoreThanExpected() {
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(1);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.addBytes(new byte[2], 0, 2));
+        assertEquals("Trying to add more bytes than expected", e.getMessage());
+    }
+
+    @Test
+    void testAddAllBytesFrom() throws IOException {
+        byte[] testData = getTestBytes(KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100);
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(testData.length);
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(testData);
+        builder.addAllBytesFrom(inputStream);
+
+        assertEquals(-1, inputStream.read(), "Should have reached end");
+        assertArrayEquals(testData, builder.createByteArray());
+    }
+
+    @Test
+    void testAddAllBytesFrom_LessThanExpected() {
+        int expected = 10;
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(expected);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[expected - 1]);
+
+        EOFException e = assertThrows(EOFException.class, () -> builder.addAllBytesFrom(inputStream));
+        assertEquals("Unexpected EOF; was expecting more bytes", e.getMessage());
+    }
+
+    @Test
+    void testAsOutputStream() throws IOException {
+        byte[] testData = getTestBytes(KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100);
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(testData.length);
+        OutputStream outputStream = builder.asOutputStream();
+
+        int index = 0;
+        int nextAddLength = 0;
+
+        // Test OutputStream.write(int)
+        for (; index < 5; index++) {
+            outputStream.write(testData[index]);
+        }
+
+        while (index < testData.length) {
+            byte[] array = testData.clone();
+            outputStream.write(array, index, nextAddLength);
+
+            assertArrayEquals(testData, array, "OutputStream modified content of given array");
+
+            index += nextAddLength;
+            nextAddLength = Math.min((nextAddLength + 1) * 2, testData.length - index);
+        }
+
+        assertArrayEquals(testData, builder.createByteArray());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {
+        1,
+        10,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE * 2 + 100,
+    })
+    void testCreateByteArray_LessThanExpected(int dataLength) {
+        byte[] testData = getTestBytes(dataLength);
+        // Set expected size higher than actual data length
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(testData.length + 1);
+
+        byte[] array = testData.clone();
+        builder.addBytes(array, 0, testData.length);
+        assertArrayEquals(testData, array, "Builder modified content of given array");
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.createByteArray(false));
+        assertEquals("Not all bytes have been added yet", e.getMessage());
+
+        assertArrayEquals(testData, builder.createByteArray(true));
+    }
+
+    /**
+     * Similar to {@link #testCreateByteArray_LessThanExpected(int)}, except that the expected
+     * size is set way higher than the actual size.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {
+        1,
+        10,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE + 100,
+        KnownSizeByteArrayBuilder.INITIAL_SECTION_SIZE * 2 + 100,
+    })
+    void testCreateByteArray_LotLessThanExpected(int dataLength) {
+        byte[] testData = getTestBytes(dataLength);
+        // Set expected size higher than actual data length
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(testData.length * 3);
+
+        byte[] array = testData.clone();
+        builder.addBytes(array, 0, testData.length);
+        assertArrayEquals(testData, array, "Builder modified content of given array");
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.createByteArray(false));
+        assertEquals("Not all bytes have been added yet", e.getMessage());
+
+        assertArrayEquals(testData, builder.createByteArray(true));
+    }
+
+    @Test
+    void testCreateByteArray_MoreThanOnce() {
+        KnownSizeByteArrayBuilder builder = new KnownSizeByteArrayBuilder(1);
+        builder.addByte((byte) 1);
+
+        assertArrayEquals(new byte[] {1}, builder.createByteArray());
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.createByteArray());
+        assertEquals("Byte array has already been created", e.getMessage());
+
+        e = assertThrows(IllegalStateException.class, () -> builder.addByte((byte) 1));
+        assertEquals("Byte array has already been created", e.getMessage());
+    }
+}

--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegmentTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/segments/SosSegmentTest.java
@@ -39,7 +39,6 @@ public class SosSegmentTest{
   public void testGetComponentsTakingNoArguments() throws IOException {
       final byte[] byteArray = new byte[5];
       final SosSegment sosSegment = new SosSegment((-1044), byteArray);
-      sosSegment.getComponents();
 
       assertEquals(0, sosSegment.successiveApproximationBitHigh);
       assertEquals(0, sosSegment.successiveApproximationBitLow);


### PR DESCRIPTION
This is a general proposal for how the commons-imaging code could better handle allocations to protect against malicious image data causing high memory consumption. The changes do not show any specific exploit or similar.

Even if you don't agree with the exact code changes here, maybe the general concept is still useful? Or feel free to pick what you like, and adjust it.

----

The general concept here is that allocations go through methods of the `Allocator` class to make it explicit whether allocations are assumed to be trusted (e.g. when writing image data) or untrusted (when reading image data). Of course this is not completely foolproof, but at least it makes the intentions of the developers more clear.
The methods for untrusted allocations can perform additional validations then, such as restricting the maximum size or when pre-sizing for example an `ArrayList` to clamp the initial capacity to a reasonable maximum to then see if the (potentially malicious) image data actually provides that many elements.

The other part is the new `KnownSizeByteArrayBuilder` class which allows building an `byte[]` with a known size, but without eagerly allocating it to make sure the input data actually contains that many bytes and has not been maliciously crafted. It also avoids the overhead of boxing which a `List<Byte>` would have, and also due to starting with a known expected size it avoids creating too large temporary arrays in the process, which general "byte array builder" classes might do.
However, possibly that `KnownSizeByteArrayBuilder` class can be replaced with similar Commons IO classes and methods if you prefer that.

These changes might not cover every aspect where memory allocation could possibly be exploited for a denial of service, but I think they cover at least some. I have not tested the effect this has on performance though.

----

Originally I provided these changes privately to the commons-imaging maintainers, but apparently did not got any response at all. So I hope at least this way here this adds some value, even if it just serves as inspiration for other changes.

I know that this merge request has conflicts, but I am not planning to resolve them unless there is actually strong interest in these changes. I was already not very happy about getting no feedback at all (despite being asked to "contribute to the solution of this issue") when I originally invested quite some time into this.