### PR TITLE
Update TiffImageMetadata.java

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageMetadata.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageMetadata.java
@@ -173,11 +173,15 @@ public class TiffImageMetadata extends GenericImageMetadata {
 
         public double getLatitudeAsDegreesNorth() throws ImagingException {
             final double result = latitudeDegrees.doubleValue() + latitudeMinutes.doubleValue() / 60.0 + latitudeSeconds.doubleValue() / 3600.0;
-
-            if (latitudeRef.trim().equalsIgnoreCase("n")) {
+            /* Due to some HEIC file converters to JPG longitude and latitude strings gets converted from UNICODE 
+             * with wrong UTF-8 coding. e.g. North "N" have hex bytes hex:4e ef bf bd<br/>
+             * For that reason latitudeRef.trim().equalsIgnoreCase("n") fails. My suggestion 
+             * is to use substring(0, 1) instead of trim()
+             */
+            if (latitudeRef.substring(0, 1).equalsIgnoreCase("n")) {
                 return result;
             }
-            if (latitudeRef.trim().equalsIgnoreCase("s")) {
+            if (latitudeRef.substring(0, 1).equalsIgnoreCase("s")) {
                 return -result;
             }
             throw new ImagingException("Unknown latitude ref: \"" + latitudeRef + "\"");
@@ -186,10 +190,10 @@ public class TiffImageMetadata extends GenericImageMetadata {
         public double getLongitudeAsDegreesEast() throws ImagingException {
             final double result = longitudeDegrees.doubleValue() + longitudeMinutes.doubleValue() / 60.0 + longitudeSeconds.doubleValue() / 3600.0;
 
-            if (longitudeRef.trim().equalsIgnoreCase("e")) {
+            if (longitudeRef.substring(0, 1).equalsIgnoreCase("e")) {
                 return result;
             }
-            if (longitudeRef.trim().equalsIgnoreCase("w")) {
+            if (longitudeRef.substring(0, 1).equalsIgnoreCase("w")) {
                 return -result;
             }
             throw new ImagingException("Unknown longitude ref: \"" + longitudeRef + "\"");


### PR DESCRIPTION
Due to some HEIC file converters to JPG longitude and latitude strings gets converted from UNICODE  with wrong UTF-8 coding. e.g. North "N" have hex bytes hex:4e ef bf bd For that reason latitudeRef.trim().equalsIgnoreCase("n") fails. My suggestion  is to use substring(0, 1) instead of trim()

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
