### PR TITLE
Fix int overflow in PCX image buffer sizing, now throws AllocationRequestException

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxImageParser.java
@@ -311,7 +311,7 @@ public class PcxImageParser extends AbstractImageParser<PcxImagingParameters> {
         if ((pcxHeader.bitsPerPixel == 1 || pcxHeader.bitsPerPixel == 2 || pcxHeader.bitsPerPixel == 4 || pcxHeader.bitsPerPixel == 8)
                 && pcxHeader.nPlanes == 1) {
             final int bytesPerImageRow = (xSize * pcxHeader.bitsPerPixel + 7) / 8;
-            final byte[] image = Allocator.byteArray(ySize * bytesPerImageRow);
+            final byte[] image = Allocator.byteArray((long) ySize * bytesPerImageRow);
             for (int y = 0; y < ySize; y++) {
                 rleReader.read(is, scanline);
                 System.arraycopy(scanline, 0, image, y * bytesPerImageRow, bytesPerImageRow);
@@ -370,7 +370,7 @@ public class PcxImageParser extends AbstractImageParser<PcxImagingParameters> {
         }
         if (pcxHeader.bitsPerPixel == 8 && pcxHeader.nPlanes == 3) {
             final byte[][] image = new byte[3][];
-            final int xySize = xSize * ySize;
+            final long xySize = (long) xSize * ySize;
             image[0] = Allocator.byteArray(xySize);
             image[1] = Allocator.byteArray(xySize);
             image[2] = Allocator.byteArray(xySize);
@@ -390,7 +390,7 @@ public class PcxImageParser extends AbstractImageParser<PcxImagingParameters> {
             throw new ImagingException("Invalid/unsupported image with bitsPerPixel " + pcxHeader.bitsPerPixel + " and planes " + pcxHeader.nPlanes);
         }
         final int rowLength = 3 * xSize;
-        final byte[] image = Allocator.byteArray(rowLength * ySize);
+        final byte[] image = Allocator.byteArray((long) rowLength * ySize);
         for (int y = 0; y < ySize; y++) {
             rleReader.read(is, scanline);
             if (pcxHeader.bitsPerPixel == 24) {

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/PcxImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/PcxImageParserTest.java
@@ -26,8 +26,8 @@ class PcxImageParserTest {
 
     /**
      * A 24-bit PCX header whose width and height are both 65536 makes {@code rowLength * ySize} overflow {@code int} and wrap to a tiny value, which used to
-     * slip past the {@link AllocationRequestException} guard and allocate an undersized buffer. The size is now computed in {@code long}, so the real request is
-     * rejected.
+     * slip past the {@link AllocationRequestException} guard and allocate an undersized buffer. The size is now computed in {@code long}, so the real
+     * request is rejected.
      */
     @Test
     void testBufferSizeOverflow() {

--- a/src/test/java/org/apache/commons/imaging/formats/pcx/PcxImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/pcx/PcxImageParserTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.formats.pcx;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.commons.imaging.common.AllocationRequestException;
+import org.junit.jupiter.api.Test;
+
+class PcxImageParserTest {
+
+    /**
+     * A 24-bit PCX header whose width and height are both 65536 makes {@code rowLength * ySize} overflow {@code int} and wrap to a tiny value, which used to
+     * slip past the {@link AllocationRequestException} guard and allocate an undersized buffer. The size is now computed in {@code long}, so the real request is
+     * rejected.
+     */
+    @Test
+    void testBufferSizeOverflow() {
+        final byte[] bytes = new byte[128];
+        bytes[0] = 10; // manufacturer
+        bytes[1] = 5; // version
+        bytes[2] = 0; // encoding (uncompressed)
+        bytes[3] = 24; // bitsPerPixel
+        // xMin = 0, yMin = 0
+        // xMax = 65535 (little-endian), so xSize = 65536
+        bytes[8] = (byte) 0xFF;
+        bytes[9] = (byte) 0xFF;
+        // yMax = 65535 (little-endian), so ySize = 65536
+        bytes[10] = (byte) 0xFF;
+        bytes[11] = (byte) 0xFF;
+        bytes[65] = 1; // nPlanes
+        bytes[66] = 8; // bytesPerLine
+        assertThrows(AllocationRequestException.class, () -> new PcxImageParser().getBufferedImage(bytes, null));
+    }
+}


### PR DESCRIPTION
Reading the PCX decoder I noticed `getBufferedImage` sizes the pixel buffer with int multiplies of `xSize`/`ySize`, which both come from uint16 header fields and can reach 65536. For 24/32-bit and 8-bit/3-plane images `rowLength * ySize`, `xSize * ySize` and `ySize * bytesPerImageRow` overflow int and wrap small, so the value slips past the `Allocator` 1 GB guard and an undersized buffer feeds an out-of-bounds `arraycopy`. Computing in long lets the existing `Allocator.byteArray(long)` overload reject the real size instead.